### PR TITLE
Support for the dragonflight enchant/socket system

### DIFF
--- a/Core/Profile.lua
+++ b/Core/Profile.lua
@@ -459,6 +459,7 @@ P.armory = {
     enchantTextEnabled = true,
     abbreviateEnchantText = true,
     missingEnchantText = true,
+    missingSocketText = false,
 
     itemQualityGradientEnabled = true,
     itemQualityGradientWidth = 65,

--- a/Modules/Options/Armory/Core.lua
+++ b/Modules/Options/Armory/Core.lua
@@ -960,6 +960,15 @@ function O:Armory()
         disabled = optionsDisabled,
       }
 
+      -- Missing Socket
+      enchantGroup.missingSocketText = {
+        order = self:GetOrder(),
+        type = "toggle",
+        desc = "Shows a red 'Missing' string when you're missing a socket.",
+        name = "Missing Sockets",
+        disabled = optionsDisabled,
+      }
+
       -- Abbreviate Enchant
       enchantGroup.abbreviateEnchantText = {
         order = self:GetOrder(),

--- a/Modules/Plugins/Armory.lua
+++ b/Modules/Plugins/Armory.lua
@@ -44,16 +44,19 @@ A.characterSlots = {
   ["HeadSlot"] = {
     id = 1,
     needsEnchant = false,
+    needsSocket = false,
     direction = A.enumDirection.LEFT,
   },
   ["NeckSlot"] = {
     id = 2,
     needsEnchant = false,
+    needsSocket = true,
     direction = A.enumDirection.LEFT,
   },
   ["ShoulderSlot"] = {
     id = 3,
     needsEnchant = false,
+    needsSocket = false,
     direction = A.enumDirection.LEFT,
   },
   ["BackSlot"] = {
@@ -62,6 +65,7 @@ A.characterSlots = {
     enchantCondition = {
       level = 70,
     },
+    needsSocket = false,
     direction = A.enumDirection.LEFT,
   },
   ["ChestSlot"] = {
@@ -70,16 +74,19 @@ A.characterSlots = {
     enchantCondition = {
       level = 70,
     },
+    needsSocket = false,
     direction = A.enumDirection.LEFT,
   },
   ["ShirtSlot"] = {
     id = 4,
     needsEnchant = false,
+    needsSocket = false,
     direction = A.enumDirection.LEFT,
   },
   ["TabardSlot"] = {
     id = 18,
     needsEnchant = false,
+    needsSocket = false,
     direction = A.enumDirection.LEFT,
   },
   ["WristSlot"] = {
@@ -88,16 +95,19 @@ A.characterSlots = {
     enchantCondition = {
       level = 70,
     },
+    needsSocket = false,
     direction = A.enumDirection.LEFT,
   },
   ["HandsSlot"] = {
     id = 10,
     needsEnchant = false,
+    needsSocket = false,
     direction = A.enumDirection.RIGHT,
   },
   ["WaistSlot"] = {
     id = 6,
     needsEnchant = false,
+    needsSocket = false,
     direction = A.enumDirection.RIGHT,
   },
   ["LegsSlot"] = {
@@ -106,6 +116,7 @@ A.characterSlots = {
     enchantCondition = {
       level = 70,
     },
+    needsSocket = false,
     direction = A.enumDirection.RIGHT,
   },
   ["FeetSlot"] = {
@@ -114,6 +125,7 @@ A.characterSlots = {
     enchantCondition = {
       level = 70,
     },
+    needsSocket = false,
     direction = A.enumDirection.RIGHT,
   },
   ["Finger0Slot"] = {
@@ -122,6 +134,7 @@ A.characterSlots = {
     enchantCondition = {
       level = 70,
     },
+    needsSocket = false,
     direction = A.enumDirection.RIGHT,
   },
   ["Finger1Slot"] = {
@@ -130,16 +143,19 @@ A.characterSlots = {
     enchantCondition = {
       level = 70,
     },
+    needsSocket = false,
     direction = A.enumDirection.RIGHT,
   },
   ["Trinket0Slot"] = {
     id = 13,
     needsEnchant = false,
+    needsSocket = false,
     direction = A.enumDirection.RIGHT,
   },
   ["Trinket1Slot"] = {
     id = 14,
     needsEnchant = false,
+    needsSocket = false,
     direction = A.enumDirection.RIGHT,
   },
   ["MainHandSlot"] = {
@@ -148,6 +164,7 @@ A.characterSlots = {
     enchantCondition = {
       level = 70,
     },
+    needsSocket = false,
     direction = A.enumDirection.RIGHT,
   },
   ["SecondaryHandSlot"] = {
@@ -156,6 +173,7 @@ A.characterSlots = {
     enchantCondition = {
       itemType = LE_ITEM_CLASS_WEAPON,
     },
+    needsSocket = false,
     direction = A.enumDirection.LEFT,
   },
 }
@@ -476,7 +494,7 @@ function A:UpdatePageStrings(_, slotId, _, slotItem, slotInfo, which)
   local slotOptions = self.characterSlots[slotName]
   if not slotOptions then return end
 
-  -- Enchant Text Handling
+  -- Enchant/Socket Text Handling
   if self.db.pageInfo.enchantTextEnabled and slotInfo.itemLevelColors and next(slotInfo.itemLevelColors) then
     if slotInfo.enchantColors and next(slotInfo.enchantColors) then
       if slotInfo.enchantText and (slotInfo.enchantText ~= "") then
@@ -491,6 +509,14 @@ function A:UpdatePageStrings(_, slotId, _, slotItem, slotInfo, which)
     elseif self.db.pageInfo.missingEnchantText and slotOptions.needsEnchant then
       if not slotOptions.enchantCondition or (self:CheckEnchantCondition(slotOptions)) then
         slotItem.enchantText:SetText(F.String.Error("Missing"))
+      else
+        slotItem.enchantText:SetText("")
+      end
+    elseif self.db.pageInfo.missingSocketText and slotOptions.needsSocket then
+      local gemStep = 1
+      local gem = slotInfo.gems and slotInfo.gems[gemStep]
+      if not gem then
+        slotItem.enchantText:SetText(F.String.Error("No Socket"))
       else
         slotItem.enchantText:SetText("")
       end

--- a/Modules/Plugins/Armory.lua
+++ b/Modules/Plugins/Armory.lua
@@ -59,11 +59,17 @@ A.characterSlots = {
   ["BackSlot"] = {
     id = 15,
     needsEnchant = true,
+    enchantCondition = {
+      level = 70,
+    },
     direction = A.enumDirection.LEFT,
   },
   ["ChestSlot"] = {
     id = 5,
     needsEnchant = true,
+    enchantCondition = {
+      level = 70,
+    },
     direction = A.enumDirection.LEFT,
   },
   ["ShirtSlot"] = {
@@ -80,18 +86,13 @@ A.characterSlots = {
     id = 9,
     needsEnchant = true,
     enchantCondition = {
-      level = 60,
-      primary = LE_UNIT_STAT_INTELLECT,
+      level = 70,
     },
     direction = A.enumDirection.LEFT,
   },
   ["HandsSlot"] = {
     id = 10,
-    needsEnchant = true,
-    enchantCondition = {
-      level = 60,
-      primary = LE_UNIT_STAT_STRENGTH,
-    },
+    needsEnchant = false,
     direction = A.enumDirection.RIGHT,
   },
   ["WaistSlot"] = {
@@ -101,26 +102,34 @@ A.characterSlots = {
   },
   ["LegsSlot"] = {
     id = 7,
-    needsEnchant = false,
+    needsEnchant = true,
+    enchantCondition = {
+      level = 70,
+    },
     direction = A.enumDirection.RIGHT,
   },
   ["FeetSlot"] = {
     id = 8,
     needsEnchant = true,
     enchantCondition = {
-      level = 60,
-      primary = LE_UNIT_STAT_AGILITY,
+      level = 70,
     },
     direction = A.enumDirection.RIGHT,
   },
   ["Finger0Slot"] = {
     id = 11,
     needsEnchant = true,
+    enchantCondition = {
+      level = 70,
+    },
     direction = A.enumDirection.RIGHT,
   },
   ["Finger1Slot"] = {
     id = 12,
     needsEnchant = true,
+    enchantCondition = {
+      level = 70,
+    },
     direction = A.enumDirection.RIGHT,
   },
   ["Trinket0Slot"] = {
@@ -136,6 +145,9 @@ A.characterSlots = {
   ["MainHandSlot"] = {
     id = 16,
     needsEnchant = true,
+    enchantCondition = {
+      level = 70,
+    },
     direction = A.enumDirection.RIGHT,
   },
   ["SecondaryHandSlot"] = {


### PR DESCRIPTION
# Summary of Changes

1. Updates the required enchants from the SL slots/requirements to the DF enchants
2. Adds an optional feature that will let you know sockets are missing on your neck

# Description

Changes the enchant slots to only show at level 70 as well as show the slots that Dragonflight supports with enchants
Also adds a feature to check if the neck is missing sockets which can be added with the jewelcrafting item on the AH

# To test

-   [ ] Open armory
-   [ ] When having no enchants check if the Back/Chest/Wrist/Pants/Boots/Rings/Weapons are saying 'Missing'
-   [ ] The necklace slot should show no warning by default when no socket slots exist
-   [ ] Go into /tx and under Armory -> Item Slot -> enchant Strings check the option 'Missing Sockets' (check if default is off)
-   [ ] Wear necklace with socket slots and there should be no red warning
-   [ ] Swap necklace with no socket slots and it should say No Socket
