### PR TITLE
📦 NEW: missing sockets and enchants code

### DIFF
--- a/Core/Changelog/6.1.0.lua
+++ b/Core/Changelog/6.1.0.lua
@@ -13,8 +13,8 @@ TXUI.Changelog["6.1.0"] = {
   end,
   CHANGES = {
     "* ToxiUI",
-    F.String.Good("New: ") .. "Refactored whole options window",
-    F.String.Good("New: ") .. "Font changing feature " .. F.String.Error("[EXPERIMENTAL]"),
+    F.String.Good("[NEW] ") .. "Refactored whole options window",
+    F.String.Good("[NEW] ") .. "Font changing feature " .. F.String.Error("[EXPERIMENTAL]"),
     "Gradient Mode rewritten, better performance",
     "Lots of fixes for Dragonflight " .. F.String.Error("[Please report bugs on GitHub or Discord!]"),
 
@@ -23,7 +23,7 @@ TXUI.Changelog["6.1.0"] = {
     "Tooltip: Change health bar height",
 
     "* Details",
-    F.String.Good("New: ") .. "Skin with icons, in collaboration with Redtuzk" .. F.String.Error("UI"),
+    F.String.Good("[NEW] ") .. "Skin with icons, in collaboration with Redtuzk" .. F.String.Error("UI"),
 
     "* Boss Mods",
     "BigWigs: Update to match Details",

--- a/Core/Changelog/6.1.2.lua
+++ b/Core/Changelog/6.1.2.lua
@@ -5,11 +5,11 @@ TXUI.Changelog["6.1.2"] = {
   CHANGES = {
     "* ToxiUI",
     "Fix Gradient Mode's Dead unit color",
-    F.String.Good("New: ") .. "Evoker spec icons. Credits to " .. F.String.Class("Nawuko", "MONK"),
+    F.String.Good("[NEW] ") .. "Evoker spec icons. Credits to " .. F.String.Class("Nawuko", "MONK"),
     "WunderBar: Add Valdrakken & Tol Barad portals for mages",
     "WunderBar: Change default background",
     "Armory: Update enchant slots for Dragonflight",
-    "Armory: Socket warning for neck slot. Credits to " .. F.String.Epic("Ryada"),
+    F.String.Good("[NEW] ") .. "Armory: Socket warning for neck slot. Credits to " .. F.String.Epic("Ryada"),
 
     "* ElvUI",
     "Movers: Move the Dragon Riding Vigor bar to the bottom",

--- a/Core/Functions/String.lua
+++ b/Core/Functions/String.lua
@@ -239,3 +239,10 @@ function F.String.FastGradientHex(text, h1, h2)
 
   return F.String.FastGradient(text, r1, g1, b1, r2, g2, b2)
 end
+
+function F.String.FastColorGradientHex(percentage, h1, h2)
+  local r2, g2, b2 = F.String.HexToRGB(h2)
+  local r1, g1, b1 = F.String.HexToRGB(h1)
+
+  return F.FastColorGradient(percentage, r1, g1, b1, r2, g2, b2)
+end

--- a/Core/Functions/String.lua
+++ b/Core/Functions/String.lua
@@ -241,8 +241,8 @@ function F.String.FastGradientHex(text, h1, h2)
 end
 
 function F.String.FastColorGradientHex(percentage, h1, h2)
-  local r2, g2, b2 = F.String.HexToRGB(h2)
   local r1, g1, b1 = F.String.HexToRGB(h1)
+  local r2, g2, b2 = F.String.HexToRGB(h2)
 
   return F.FastColorGradient(percentage, r1, g1, b1, r2, g2, b2)
 end

--- a/Core/Profile.lua
+++ b/Core/Profile.lua
@@ -459,7 +459,7 @@ P.armory = {
     enchantTextEnabled = true,
     abbreviateEnchantText = true,
     missingEnchantText = true,
-    missingSocketText = false,
+    missingSocketText = true,
 
     itemQualityGradientEnabled = true,
     itemQualityGradientWidth = 65,

--- a/Modules/Options/Armory/Core.lua
+++ b/Modules/Options/Armory/Core.lua
@@ -932,9 +932,9 @@ function O:Armory()
     do
       -- Enchant Group
       local enchantGroup = self:AddInlineDesc(tab, {
-        name = "Enchant Strings",
+        name = "Enchant & Socket Strings",
       }, {
-        name = "Settings for strings displaying enchant info about your item.\n\n",
+        name = "Settings for strings displaying enchant and socket info about your item.\n\n",
       }).args
 
       -- Enable

--- a/Modules/Options/Armory/Core.lua
+++ b/Modules/Options/Armory/Core.lua
@@ -955,7 +955,7 @@ function O:Armory()
       enchantGroup.missingEnchantText = {
         order = self:GetOrder(),
         type = "toggle",
-        desc = "Shows a red 'Missing' string when you're missing an enchant.",
+        desc = "Shows a warning when you're missing an enchant.",
         name = "Missing Enchants",
         disabled = optionsDisabled,
       }
@@ -964,7 +964,7 @@ function O:Armory()
       enchantGroup.missingSocketText = {
         order = self:GetOrder(),
         type = "toggle",
-        desc = "Shows a red 'Missing' string when you're missing a socket.",
+        desc = "Shows a warning when you're missing sockets on your necklace.",
         name = "Missing Sockets",
         disabled = optionsDisabled,
       }

--- a/Modules/Plugins/Armory.lua
+++ b/Modules/Plugins/Armory.lua
@@ -56,7 +56,7 @@ A.characterSlots = {
     id = 2,
     needsEnchant = false,
     needsSocket = true,
-    messageCondition = {
+    warningCondition = {
       level = 70,
     },
     direction = A.enumDirection.LEFT,
@@ -70,7 +70,7 @@ A.characterSlots = {
   ["BackSlot"] = {
     id = 15,
     needsEnchant = true,
-    messageCondition = {
+    warningCondition = {
       level = 70,
     },
     needsSocket = false,
@@ -79,7 +79,7 @@ A.characterSlots = {
   ["ChestSlot"] = {
     id = 5,
     needsEnchant = true,
-    messageCondition = {
+    warningCondition = {
       level = 70,
     },
     needsSocket = false,
@@ -100,7 +100,7 @@ A.characterSlots = {
   ["WristSlot"] = {
     id = 9,
     needsEnchant = true,
-    messageCondition = {
+    warningCondition = {
       level = 70,
     },
     needsSocket = false,
@@ -121,7 +121,7 @@ A.characterSlots = {
   ["LegsSlot"] = {
     id = 7,
     needsEnchant = true,
-    messageCondition = {
+    warningCondition = {
       level = 70,
     },
     needsSocket = false,
@@ -130,7 +130,7 @@ A.characterSlots = {
   ["FeetSlot"] = {
     id = 8,
     needsEnchant = true,
-    messageCondition = {
+    warningCondition = {
       level = 70,
     },
     needsSocket = false,
@@ -139,7 +139,7 @@ A.characterSlots = {
   ["Finger0Slot"] = {
     id = 11,
     needsEnchant = true,
-    messageCondition = {
+    warningCondition = {
       level = 70,
     },
     needsSocket = false,
@@ -148,7 +148,7 @@ A.characterSlots = {
   ["Finger1Slot"] = {
     id = 12,
     needsEnchant = true,
-    messageCondition = {
+    warningCondition = {
       level = 70,
     },
     needsSocket = false,
@@ -169,7 +169,7 @@ A.characterSlots = {
   ["MainHandSlot"] = {
     id = 16,
     needsEnchant = true,
-    messageCondition = {
+    warningCondition = {
       level = 70,
     },
     needsSocket = false,
@@ -178,7 +178,7 @@ A.characterSlots = {
   ["SecondaryHandSlot"] = {
     id = 17,
     needsEnchant = true,
-    messageCondition = {
+    warningCondition = {
       itemType = LE_ITEM_CLASS_WEAPON,
       level = 70,
     },
@@ -199,7 +199,7 @@ function A:GetSlotNameByID(slotId)
 end
 
 function A:CheckMessageCondition(slotOptions)
-  local conditions = slotOptions.messageCondition
+  local conditions = slotOptions.warningCondition
   local enchantNeeded = true
 
   -- Level Condition
@@ -521,13 +521,13 @@ function A:UpdatePageStrings(_, slotId, _, slotItem, slotInfo, which)
         end
       end
     elseif self.db.pageInfo.missingEnchantText and slotOptions.needsEnchant then
-      if not slotOptions.messageCondition or (self:CheckMessageCondition(slotOptions)) then
+      if not slotOptions.warningCondition or (self:CheckMessageCondition(slotOptions)) then
         slotItem.enchantText:SetText(F.String.Error("Missing"))
       else
         slotItem.enchantText:SetText("")
       end
     elseif self.db.pageInfo.missingSocketText and slotOptions.needsSocket then
-      if not slotOptions.messageCondition or (self:CheckMessageCondition(slotOptions)) then
+      if not slotOptions.warningCondition or (self:CheckMessageCondition(slotOptions)) then
         local missingGemSlots = 3 - #slotInfo.gems
         if missingGemSlots > 0 then
           local text = format("Missing %d", missingGemSlots)

--- a/Modules/Plugins/Armory.lua
+++ b/Modules/Plugins/Armory.lua
@@ -41,9 +41,9 @@ local wipe = wipe
 -- Vars
 A.enumDirection = F.Enum { "LEFT", "RIGHT", "BOTTOM" }
 A.colors = {
-  LIGHT_GREEN = "12E626",
-  DARK_GREEN = "00B01C",
-  RED = "F0544F",
+  LIGHT_GREEN = "#12E626",
+  DARK_GREEN = "#00B01C",
+  RED = "#F0544F",
 }
 A.characterSlots = {
   ["HeadSlot"] = {


### PR DESCRIPTION
# Summary of Changes

1. Shows how many sockets are missing in the message
2. Changes the color of the message depending on how many sockets are missing
3. Added level requirement to necklace
4. Updated strings in the settings to include sockets and enchants
5. Updated code to remove some magic numbers with colors
6. Updated code to self document a little more

# Description

Intent of the PR was to update the socket warning message with the amount of sockets missing and adding a color to it that changes the more sockets you have, so people are less inclined to get a red warning of their screen by spending a lot of money for the 3rd socket.
Added level 70 requirement to the necklaces before showing a warning
When this was done I noticed that the code contained some repeating magic numbers as well as inconsistencies for the end user with regards to setting strings, so I updated that to improve the code.

# To test

- [x] Sub level 70 no necklace warning visible
- [x] On level 70 wear necklaces with different amount of sockets to check the missing text and color
- [x] Check if the strings in the /tx settings -> Armory -> Item slots are clear
- [x] Check if the colors on enchants are still the correct color
