### PR TITLE
👌 IMPROVE: Focus Frame reposition

### DIFF
--- a/Core/Internal.lua
+++ b/Core/Internal.lua
@@ -202,6 +202,7 @@ I.GradientMode = {
         ["tanktarget"] = true,
         ["assist"] = true,
         ["assisttarget"] = true,
+        ["focus"] = true,
       },
 
       -- Right DPS Gradient

--- a/Core/Internal.lua
+++ b/Core/Internal.lua
@@ -202,7 +202,6 @@ I.GradientMode = {
         ["tanktarget"] = true,
         ["assist"] = true,
         ["assisttarget"] = true,
-        ["focus"] = true,
       },
 
       -- Right DPS Gradient
@@ -211,6 +210,7 @@ I.GradientMode = {
         ["targettarget"] = true,
         ["arena"] = true,
         ["boss"] = true,
+        ["focus"] = true,
       },
     },
   },

--- a/Modules/Profiles/BigWigs.lua
+++ b/Modules/Profiles/BigWigs.lua
@@ -62,7 +62,7 @@ function PF:BuildBigWigsProfile()
             ["spacing"] = 5,
             ["texture"] = "- Tx Left",
             ["visibleBarLimit"] = 8,
-            ["visibleBarLimitEmph"] = 8,
+            ["visibleBarLimitEmph"] = 4,
           },
         },
       },

--- a/Modules/Profiles/ElvUI/Profile.lua
+++ b/Modules/Profiles/ElvUI/Profile.lua
@@ -136,7 +136,7 @@ function PF:BuildProfile()
       ElvUF_PlayerCastbarMover = F.Position("TOPLEFT", "ElvUF_Player", "BOTTOMLEFT", 0, -defaultPadding),
       ElvUF_TargetCastbarMover = F.Position("TOPRIGHT", "ElvUF_Target", "BOTTOMRIGHT", 0, -defaultPadding),
 
-      ElvUF_FocusMover = F.Position("TOP", "ElvUF_Player", "BOTTOM", 0, -60),
+      ElvUF_FocusMover = F.Position("TOP", "ElvUF_Target", "BOTTOM", 0, -60),
       FocusPowerBarMover = F.Position("TOP", "ElvUF_FocusMover", "BOTTOM", 0, defaultPadding),
       ElvUF_FocusCastbarMover = F.Position("TOPLEFT", "ElvUF_Focus", "BOTTOMLEFT", 0, -defaultPadding),
 

--- a/Modules/Profiles/ElvUI/Profile.lua
+++ b/Modules/Profiles/ElvUI/Profile.lua
@@ -136,7 +136,7 @@ function PF:BuildProfile()
       ElvUF_PlayerCastbarMover = F.Position("TOPLEFT", "ElvUF_Player", "BOTTOMLEFT", 0, -defaultPadding),
       ElvUF_TargetCastbarMover = F.Position("TOPRIGHT", "ElvUF_Target", "BOTTOMRIGHT", 0, -defaultPadding),
 
-      ElvUF_FocusMover = F.Position("BOTTOM", "ElvAB_1", "TOP", 0, 60),
+      ElvUF_FocusMover = F.Position("TOP", "ElvUF_Player", "BOTTOM", 0, -60),
       FocusPowerBarMover = F.Position("TOP", "ElvUF_FocusMover", "BOTTOM", 0, defaultPadding),
       ElvUF_FocusCastbarMover = F.Position("TOPLEFT", "ElvUF_Focus", "BOTTOMLEFT", 0, -defaultPadding),
 
@@ -751,7 +751,7 @@ function PF:BuildProfile()
       -- UnitFrame Focus Custom Texts Health
       ["!Health"] = createCustomText({}, {
         justifyH = "RIGHT",
-        text_format = "[tx:classcolor][health:current:shortvalue] || [perhp]",
+        text_format = "[tx:classcolor][perhp]",
         xOffset = F.Dpi(-10),
         yOffset = F.ChooseForTheme(F.Dpi(25), F.Dpi(0)),
       }),
@@ -759,7 +759,7 @@ function PF:BuildProfile()
 
     -- UnitFrame Focus Buffs
     buffs = {
-      enable = true,
+      enable = false,
       anchorPoint = "TOPLEFT",
       maxDuration = 0,
       perrow = 5,

--- a/Modules/Profiles/ElvUI/Profile.lua
+++ b/Modules/Profiles/ElvUI/Profile.lua
@@ -216,7 +216,7 @@ function PF:BuildProfile()
       ElvUF_PlayerMover = F.Position("BOTTOM", "ElvUIParent", "BOTTOM", -325, 380),
       ElvUF_TargetMover = F.Position("BOTTOM", "ElvUIParent", "BOTTOM", 325, 380),
 
-      ElvUF_FocusMover = F.Position("BOTTOMLEFT", "ElvUF_PlayerMover", "TOPLEFT", 0, 160),
+      ElvUF_FocusMover = F.Position("BOTTOMLEFT", "ElvUF_Target", "TOPLEFT", 0, 160),
       FocusPowerBarMover = F.Position("TOP", "ElvUF_FocusMover", "BOTTOM", 0, defaultPadding),
       ElvUF_FocusCastbarMover = F.Position("TOPLEFT", "ElvUF_FocusMover", "BOTTOMLEFT", 0, -defaultPadding),
 
@@ -743,16 +743,17 @@ function PF:BuildProfile()
     customTexts = {
       -- UnitFrame Focus Custom Texts Name
       ["!Name"] = createCustomText({}, {
+        justifyH = "RIGHT",
         text_format = "[tx:classcolor][name:medium]",
-        xOffset = F.Dpi(5),
+        xOffset = F.Dpi(-5),
         yOffset = F.ChooseForTheme(F.Dpi(25), F.Dpi(0)),
       }),
 
       -- UnitFrame Focus Custom Texts Health
       ["!Health"] = createCustomText({}, {
-        justifyH = "RIGHT",
+        justifyH = "LEFT",
         text_format = "[tx:classcolor][perhp]",
-        xOffset = F.Dpi(-10),
+        xOffset = F.Dpi(10),
         yOffset = F.ChooseForTheme(F.Dpi(25), F.Dpi(0)),
       }),
     },


### PR DESCRIPTION
# Summary of Changes
1. Move the Focus frame below Target frame **for DPS layout**
2. Move the Focus frame above Target frame **for Healer layout**
3. Disable buffs for the Focus frame
4. Remove raw hp text, leave only percent hp
6. Change gradient direction
7. Reduce BigWigs emphasized bar limit to 4
   - On healer layout it would clip with focus in those rare occasions where you might have >4 bars

# Description
- The old focus frame position (centered below WAs) was overlapping with WAs and overall wasn't satisfied with that position
- I'm also thinking of maybe changing the way we show party/focus health and increase the font size, move it more into the frame since that's crucial info and doesn't take up much space

# Screenshots
![image](https://user-images.githubusercontent.com/69549795/208306241-5e4e03ad-dfa4-4894-b9ac-b124bdf4c1d4.png)

# To test

- [ ] `git checkout focus-frame`
- [ ] Run `/tx install` with DPS layout
- [ ] Test new focus frame and see if no overlaps etc.
