### PR TITLE
Vehicle bar taint

### DIFF
--- a/Core/Animations.lua
+++ b/Core/Animations.lua
@@ -995,7 +995,10 @@ end
 Update["move"] = function(self, elapsed, i)
   self.Timer = self.Timer + elapsed
 
-  if self.Timer >= self.Duration then
+  if UnitAffectingCombat("player") then
+    tremove(Update, i)
+    self.Playing = false
+  elseif self.Timer >= self.Duration then
     tremove(Updater, i)
     self.Parent:SetPoint(self.A1, self.P, self.A2, self.EndX, self.EndY)
     self.Playing = false

--- a/Core/Animations.lua
+++ b/Core/Animations.lua
@@ -995,10 +995,7 @@ end
 Update["move"] = function(self, elapsed, i)
   self.Timer = self.Timer + elapsed
 
-  if UnitAffectingCombat("player") then
-    tremove(Update, i)
-    self.Playing = false
-  elseif self.Timer >= self.Duration then
+  if self.Timer >= self.Duration then
     tremove(Updater, i)
     self.Parent:SetPoint(self.A1, self.P, self.A2, self.EndX, self.EndY)
     self.Playing = false

--- a/Modules/Plugins/VehicleBar.lua
+++ b/Modules/Plugins/VehicleBar.lua
@@ -91,6 +91,7 @@ end
 
 function VB:OnCombatEvent(toggle)
   self.combatLock = toggle
+  if self.combatLock then self:StopAllAnimations() end
 end
 
 function VB:UpdateBar()


### PR DESCRIPTION
Closes #1 

# Summary of Changes

1. Properly handles going into combat when trying to mount up on the Dragonflight mount.

# Description

Previously it was possible to reliably taint the vehicle bar by trying to mount up and getting in combat during the 1.5 second cast of it. This should now be handled gracefully and not leave the UI in a tainted/broken state.

# To test

- [ ] Go to a patrolling mob.
- [ ] Position yourself along its patrol.
- [ ] Try mounting up just before you get into combat with the patrol
- [ ] Should not throw errors and after killing the mob should place the vehicle bar in the correct position on the screen with animation. 
