### PR TITLE
FIX: Correctly style details deaths when using gradient theme.

### DIFF
--- a/Modules/Skins/Details/Gradients.lua
+++ b/Modules/Skins/Details/Gradients.lua
@@ -29,7 +29,14 @@ end
 function SD:GetRowColor(frame)
   local actor = frame.minha_tabela
   if actor then
-    local classId = actor:class()
+    local classId
+    if actor.class then
+      classId = actor:class()
+    elseif actor[4] then
+      -- Index 4 is the element that holds the classId
+      -- If this breaks in the future it is likely this element has moved
+      classId = actor[4]
+    end
     if classId and classId ~= "UNKNOW" then return "classColorMap", classId end
   end
 end


### PR DESCRIPTION
# Summary of Changes

1. Resolves an issue with details gradient theme where bars were sometimes not correctly styled.

# Description
Some details report types have bars that do not have an `actor()` method implemented.
In these cases the required class id is stored in a table on an unnamed element at index 4.
This seems fragile, but there is also not any other clear way to access the requisite class id using only what is passed to the existing GetRowColor method.

# To test

- Checkout the changes in the PR
- Load the game and change a details window to Deaths 
- Die
- Observe gradient should now display correctly