### PR TITLE
FIX: use correct WoW API variable for weapon item class

### DIFF
--- a/Modules/Plugins/Armory.lua
+++ b/Modules/Plugins/Armory.lua
@@ -20,7 +20,7 @@ local GetSpecializationRole = GetSpecializationRole
 local GetTitleName = GetTitleName
 local InCombatLockdown = InCombatLockdown
 local ipairs = ipairs
-local LE_ITEM_CLASS_WEAPON = _G.LE_ITEM_CLASS_WEAPON
+local ENUM_ITEM_CLASS_WEAPON = _G.Enum.ItemClass.Weapon
 local LE_UNIT_STAT_AGILITY = _G.LE_UNIT_STAT_AGILITY
 local LE_UNIT_STAT_INTELLECT = _G.LE_UNIT_STAT_INTELLECT
 local LE_UNIT_STAT_STRENGTH = _G.LE_UNIT_STAT_STRENGTH
@@ -179,7 +179,7 @@ A.characterSlots = {
     id = 17,
     needsEnchant = true,
     warningCondition = {
-      itemType = LE_ITEM_CLASS_WEAPON,
+      itemType = ENUM_ITEM_CLASS_WEAPON,
       level = 70,
     },
     needsSocket = false,


### PR DESCRIPTION
Closes #38

# Summary of Changes

1. Now we use the [correct WoW API variable](https://wowpedia.fandom.com/wiki/ItemType) for the weapon item class, the old one was removed from the API
2. Fixes problem with shield/off-hand "missing enchant" due to checking secondary hand slot item type against actual weapon item class value 

# Description

Since the `LE_ITEM_CLASS_ARMOR` variable was removed (or moved somewhere?) from `_G`, the Armory module could not correctly check whether the secondary hand slot item type was a weapon. So it fired a "missing enchant" warning for every item in the secondary hand. Replaced the old API variable with a new one, so the Armory should work as intended.

# To test

-   [x] Armory doesn't show a warning for shield
-   [x] Armory doesn't show a warning for off-hand
-   [x] Armory still shows a warning for actual weapons in the secondary hand without any enchant
