### PR TITLE
FIX: use virtual frames to use elvui datatexts

### DIFF
--- a/Modules/WunderBar/ElvUI.lua
+++ b/Modules/WunderBar/ElvUI.lua
@@ -155,6 +155,15 @@ function WB:RegisterElvUIDatatexts()
         local constructed = WB:NewModule(name)
         self:ConstructElvUIDataText(constructed, dt)
         self:RegisterSubModule(constructed, dt.events)
+
+        -- Create virtual frame and connect it to datatext
+        constructed.virtualFrame = {
+          name = dataTextName,
+          text = {
+            SetFormattedText = E.noop
+          }
+        }
+        WB:ConnectVirtualFrameToDataText(dataTextName, constructed.virtualFrame)
       end
     end
   end

--- a/Modules/WunderBar/Functions.lua
+++ b/Modules/WunderBar/Functions.lua
@@ -31,7 +31,14 @@ end
 function WB:GetElvUIDataText(name)
   local dt = DT.RegisteredDataTexts[name]
 
-  if dt and (dt.category == nil or dt.category ~= "Data Broker") then return dt end
+  if dt and dt.category ~= "Data Broker" then return dt end
+end
+
+function WB:ConnectVirtualFrameToDataText(dataTextName, virtualFrame)
+  local dt = self:GetElvUIDataText(dataTextName)
+  if dt.applySettings then
+    dt.applySettings(virtualFrame, E.media.hexvaluecolor)
+  end
 end
 
 function WB:FlashFontOnEvent(fs, icon)

--- a/Modules/WunderBar/SubModules/MicroMenu.lua
+++ b/Modules/WunderBar/SubModules/MicroMenu.lua
@@ -192,14 +192,14 @@ MM.microMenu = {
         end
       end,
 
-      -- RightButton = function(frame)
-      --   local dtModule = WB:GetElvUIDataText("Guild")
+      RightButton = function(frame)
+        local dtModule = WB:GetElvUIDataText("Guild")
 
-      --   if dtModule then
-      --     dtModule.eventFunc(WB:GetElvUIDummy(), "GUILD_ROSTER_UPDATE")
-      --     dtModule.onClick(frame, "RightButton")
-      --   end
-      -- end,
+        if dtModule then
+          dtModule.eventFunc(MM.guildVirtualFrame, "GUILD_ROSTER_UPDATE")
+          dtModule.onClick(frame, "RightButton")
+        end
+      end,
     },
   },
   ["social"] = {
@@ -219,7 +219,7 @@ MM.microMenu = {
         local dtModule = WB:GetElvUIDataText("Friends")
 
         if dtModule then
-          dtModule.eventFunc(WB:GetElvUIDummy(), nil)
+          dtModule.eventFunc(MM.friendsVirtualFrame, nil)
           dtModule.onClick(frame, "RightButton")
         end
       end,
@@ -465,12 +465,20 @@ function MM:ButtonEnter(button)
     local dtModule = WB:GetElvUIDataText("Friends")
 
     if dtModule then
-      dtModule.eventFunc(WB:GetElvUIDummy(), nil)
+      dtModule.eventFunc(MM.friendsVirtualFrame, nil)
       dtModule.onEnter()
       skipTitle = true
     end
   elseif button.id == "guild" then
-    return
+    DT.tooltip:SetOwner(button, "ANCHOR_TOP", 0, 20)
+
+    local dtModule = WB:GetElvUIDataText("Guild")
+
+    if dtModule then
+      dtModule.eventFunc(MM.guildVirtualFrame, "GUILD_ROSTER_UPDATE")
+      dtModule.onEnter()
+      skipTitle = true
+    end
   elseif button.id == "txui" then
     self:ToxiUITooltip(button)
     return
@@ -732,6 +740,30 @@ function MM:OnInit()
   self.info = {}
   self.info.friends = -1
   self.info.guildies = -1
+
+  -- Create virtual frames and connect them to datatexts
+  self.guildVirtualFrame = {
+    name = "Guild",
+    text = {
+      SetFormattedText = E.noop,
+      SetText = E.noop
+    },
+    GetScript = function()
+      return E.noop
+    end,
+    IsMouseOver = function()
+      return false
+    end
+  }
+  WB:ConnectVirtualFrameToDataText("Guild", self.guildVirtualFrame)
+
+  self.friendsVirtualFrame = {
+    name = "Friends",
+    text = {
+      SetFormattedText = E.noop
+    }
+  }
+  WB:ConnectVirtualFrameToDataText("Friends", self.friendsVirtualFrame)
 
   -- Of we go
   self:CreateButtons()

--- a/Modules/WunderBar/SubModules/System.lua
+++ b/Modules/WunderBar/SubModules/System.lua
@@ -203,12 +203,21 @@ function ST:OnInit()
   self.framerate = 0
   self.latency = 0
 
+  -- Create virtual frame and connect it to datatext
+  self.systemVirtualFrame = {
+    name = "System",
+    text = {
+      SetFormattedText = E.noop
+    }
+  }
+  WB:ConnectVirtualFrameToDataText("System", self.systemVirtualFrame)
+
   self:CreateText()
   self:OnWunderBarUpdate()
 
   -- Update data text for accurate tooltips
   local dtModule = WB:GetElvUIDataText("System")
-  if dtModule then dtModule.eventFunc(WB:GetElvUIDummy()) end
+  if dtModule then dtModule.eventFunc(self.systemVirtualFrame) end
 
   -- We are done, hooray!
   self.Initialized = true

--- a/Modules/WunderBar/SubModules/Time.lua
+++ b/Modules/WunderBar/SubModules/Time.lua
@@ -255,7 +255,7 @@ end
 
 function TI:UpdateTooltip(dataText)
   local dtModule = dataText or WB:GetElvUIDataText("Time")
-  if dtModule then dtModule.eventFunc(WB:GetElvUIDummy(), "UPDATE_INSTANCE_INFO") end
+  if dtModule then dtModule.eventFunc(self.timeVirtualFrame, "UPDATE_INSTANCE_INFO") end
 end
 
 function TI:UpdateClock()
@@ -329,6 +329,15 @@ function TI:OnInit()
   self.hasMail = false
   self.showRestingAnimation = false
   self.activeInfoText = {}
+
+  -- Create virtual frame and connect it to datatext
+  self.timeVirtualFrame = {
+    name = "Time",
+    text = {
+      SetFormattedText = E.noop
+    }
+  }
+  WB:ConnectVirtualFrameToDataText("Time", self.timeVirtualFrame)
 
   self:CreateClock()
   self:OnWunderBarUpdate()


### PR DESCRIPTION
Closes #39

# Summary of Changes

1. Added virtual frames to use them with ElvUI DataTexts
2. Reenabled right-click functionality for the Guild button on Microbar
3. Added missing Intellect DataText to ElvUI.lua

# Description

After ElvUI's refactoring of DataTexts, they require some sort of panels to be used with. WindTools author just used "virtual frames" (basically a table with a minimum set of fields, just to avoid LUA errors) for this task. Therefore I used the same idea. At least managed to reanimate those, that were broken, without breaking other DataTexts on WunderBar. And I hope I didn't break other DataTexts outside WunderBar, since I had to make some changes in the `WB:GetElvUIDataText(name)` function.

# Note

Even Int/Agi/Str DataTexts now can be used on WunderBar, they still don't have any tooltip. I suppose this is caused by missing the `OnEnter()` function in ElvUI addon sources. Others (Mastery, Crit, etc) have that function and work as intended. I think we can leave it as is, or I can try to add missing tooltips from the ToxiUI addon's side in a separate pull request.

# To test

-   [x] WunderBar's System module shows a tooltip
-   [x] WunderBar's System module accepts mouse clicks
-   [x] WunderBar's Time module shows a tooltip
-   [x] WunderBar's Time module accepts mouse clicks
-   [x] Micromenu's Friends button shows a tooltip
-   [x] Micromenu's Friends button accepts mouse clicks
-   [x] Micromenu's Guild button shows a tooltip
-   [x] Micromenu's Guild button accepts mouse clicks
-   [x] WunderBar's ElvUI modules show tooltips 