### PR TITLE
FIX: populated time virtual frame with animation-related dummy functions

### DIFF
--- a/Core/Changelog/6.2.1.lua
+++ b/Core/Changelog/6.2.1.lua
@@ -5,5 +5,6 @@ TXUI.Changelog["6.2.1"] = {
   CHANGES = {
     "* ToxiUI",
     "Misc: Add ToxiUI Addon Compartment. Credits to " .. F.String.Class("Knuffelpanda", "MONK"),
+    "WunderBar: Fixed Time module by populating its virtual frame with animation-related dummy functions. Credits to " .. F.String.Class("Stiimo", "PRIEST"),
   },
 }

--- a/Modules/WunderBar/SubModules/Time.lua
+++ b/Modules/WunderBar/SubModules/Time.lua
@@ -336,6 +336,24 @@ function TI:OnInit()
     text = {
       SetFormattedText = E.noop,
     },
+    CreateAnimationGroup = function()
+      return {
+        CreateAnimation = function()
+          return {
+            SetFromAlpha = E.noop,
+            SetToAlpha = E.noop,
+            SetOrder = E.noop,
+            SetDuration = E.noop,
+          }
+        end,
+        SetScript = E.noop,
+        Play = E.noop,
+        Stop = E.noop,
+        IsPlaying = function()
+          return false
+        end,
+      }
+    end,
   }
   WB:ConnectVirtualFrameToDataText("Time", self.timeVirtualFrame)
 


### PR DESCRIPTION
# Summary of Changes

1. Populated time virtual frame with animation-related dummy functions

# Description

Created virtual frame for the Time module was missing dummy functions, needed for animations, which causes the whole WunderBar to crash when a player gets an invite from a calendar event. This PR adds those missing functions.

# To test

-   [ ] WunderBar doesn't crash when a player gets an invite from a calendar event with ElvUI "Flash invites" option enabled. 
