### PR TITLE
Potential fix for Details and debugging prints to help rationalize

### DIFF
--- a/Modules/Themes/Gradients/Update.lua
+++ b/Modules/Themes/Gradients/Update.lua
@@ -38,7 +38,7 @@ function GR:SetGradientColors(frame, valueChanged, eR, eG, eB, colorChanged, col
         frame.normalColorBG = bgMap[I.Enum.GradientMode.Color.NORMAL][frame.colorEntry]
         frame.shiftColorBG = bgMap[I.Enum.GradientMode.Color.SHIFT][frame.colorEntry]
       else
-        -- This is for debugging DO NOT RELEASE WITH THIS IN THE CODE
+        -- @TODO: This is for debugging DO NOT RELEASE WITH THIS IN THE CODE
         print("This is for debugging an issue with Details in retail. If you are seeing this you are running a beta version.")
         print("fgMap or bgMap was nil for: " .. frame.colorMap)
         print("colorEntry: " .. frame.colorEntry)

--- a/Modules/Themes/Gradients/Update.lua
+++ b/Modules/Themes/Gradients/Update.lua
@@ -32,10 +32,17 @@ function GR:SetGradientColors(frame, valueChanged, eR, eG, eB, colorChanged, col
       local fgMap = F.Color.GetMap(frame.colorMap)
       local bgMap = F.Color.GetBackgroundMap(frame.colorMap)
 
-      frame.normalColor = fgMap[I.Enum.GradientMode.Color.NORMAL][frame.colorEntry]
-      frame.shiftColor = fgMap[I.Enum.GradientMode.Color.SHIFT][frame.colorEntry]
-      frame.normalColorBG = bgMap[I.Enum.GradientMode.Color.NORMAL][frame.colorEntry]
-      frame.shiftColorBG = bgMap[I.Enum.GradientMode.Color.SHIFT][frame.colorEntry]
+      if fgMap ~= nil and bgMap ~= nil then
+        frame.normalColor = fgMap[I.Enum.GradientMode.Color.NORMAL][frame.colorEntry]
+        frame.shiftColor = fgMap[I.Enum.GradientMode.Color.SHIFT][frame.colorEntry]
+        frame.normalColorBG = bgMap[I.Enum.GradientMode.Color.NORMAL][frame.colorEntry]
+        frame.shiftColorBG = bgMap[I.Enum.GradientMode.Color.SHIFT][frame.colorEntry]
+      else
+        -- This is for debugging DO NOT RELEASE WITH THIS IN THE CODE
+        print("This is for debugging an issue with Details in retail. If you are seeing this you are running a beta version.")
+        print("fgMap or bgMap was nil for: " .. frame.colorMap)
+        print("colorEntry: " .. frame.colorEntry)
+      end
 
       if frame.normalColor == nil then
         frame.colorMap = nil


### PR DESCRIPTION
# Summary of Changes

1. Add nil check around fgMap and bgMap with print lines when they are nil for further debugging

# Description

Nil check added for if somehow the cache doesn't contain the values we arel ooking for
Add print for when the cache returns nil so we can see the values
It should not blow up anymore and at least run to the default behavior causing no ripple effects.

# To test

-   [ ] Hard to reproduce, need to have Morbjorn from the Discord test this as they can reproduce it 100% of the time.
