### PR TITLE
Fix errors with disabling action bars

### DIFF
--- a/Core/Changelog/6.3.0.lua
+++ b/Core/Changelog/6.3.0.lua
@@ -6,6 +6,8 @@ TXUI.Changelog["6.3.0"] = {
     "* ToxiUI",
     F.String.Good("NEW: ") .. "UnitFrame Class Icons",
     F.String.Good("NEW: ") .. "Combat icon for Player UnitFrame " .. F.String.Class("(icons8.com)", "ROGUE"),
+    F.String.RandomClassColor("FadePersist: ") .. "Properly disable the module when ElvUI ActionBars are disabled",
+    F.String.RandomClassColor("VehicleBar: ") .. "Properly disable the module when ElvUI ActionBars are disabled",
   },
   CHANGES_CLASSIC = {
     "Release ToxiUI Classic",

--- a/Core/Functions/String.lua
+++ b/Core/Functions/String.lua
@@ -61,6 +61,21 @@ function F.String.Class(msg, class)
   return F.String.Color(msg, F.String.FastRGB(color.r, color.g, color.b))
 end
 
+function F.String.RandomClassColor(msg)
+  local classNames
+  if TXUI.IsClassic then
+    classNames = I.Strings.Classes.CLASSIC
+  elseif TXUI.IsWrath then
+    classNames = I.Strings.Classes.WRATH
+  else
+    classNames = I.Strings.Classes.RETAIL
+  end
+
+  local randomClass = classNames[math.random(1, #classNames)]
+  local color = E:ClassColor(randomClass, true)
+  return F.String.Color(msg, F.String.FastRGB(color.r, color.g, color.b))
+end
+
 function F.String.Luxthos(msg)
   return F.String.Color(msg, I.Enum.Colors.LUXTHOS)
 end

--- a/Core/Internal.lua
+++ b/Core/Internal.lua
@@ -125,12 +125,14 @@ I.Requirements = {
   },
   ["VehicleBar"] = {
     I.Enum.Requirements.SL_VEHICLE_BAR_DISABLED,
+    I.Enum.Requirements.ELVUI_ACTIONBARS_DISABLED,
   },
   ["MiniMapCoords"] = {
     I.Enum.Requirements.SL_MINIMAP_COORDS_DISABLED,
   },
   ["FadePersist"] = {
     I.Enum.Requirements.OLD_FADE_PERSIST_DISABLED,
+    I.Enum.Requirements.ELVUI_ACTIONBARS_DISABLED,
   },
   ["GameMenuButton"] = {},
   ["BlizzardFonts"] = {

--- a/Core/InternalEnum.lua
+++ b/Core/InternalEnum.lua
@@ -29,6 +29,7 @@ I.Enum.Requirements = F.Enum {
   "ELVUI_BAGS_ENABLED",
   "DETAILS_NOT_SKINNED",
   "OTHER_THEMES_DISABLED",
+  "ELVUI_ACTIONBARS_DISABLED",
 }
 
 -- Used for F.String.Color functions

--- a/Core/InternalString.lua
+++ b/Core/InternalString.lua
@@ -24,6 +24,7 @@ I.Strings.Requirements = {
   [I.Enum.Requirements.ELVUI_NOT_SKINNED] = "You can't enable this option because a similar module for UnitFrames is currently turned on. Please disable it to unlock this option.",
   [I.Enum.Requirements.DETAILS_NOT_SKINNED] = "You can't enable this option because a similar module for Details is currently turned on. Please disable it to unlock this option.",
   [I.Enum.Requirements.OTHER_THEMES_DISABLED] = "You can't enable this option because a similar module for ElvUI is currently turned on. Please disable it to unlock this option.",
+  [I.Enum.Requirements.ELVUI_ACTIONBARS_DISABLED] = "You can't use this module because ElvUI's ActionBars module is currently turned off. Please enable it to unlock this option.",
 }
 
 I.Strings.RequirementsDebug = {

--- a/Core/InternalString.lua
+++ b/Core/InternalString.lua
@@ -127,3 +127,47 @@ I.Strings.Deconstruct = {
     },
   },
 }
+
+I.Strings.Classes = {
+  CLASSIC = {
+    "WARRIOR",
+    "PALADIN",
+    "HUNTER",
+    "ROGUE",
+    "PRIEST",
+    "SHAMAN",
+    "MAGE",
+    "WARLOCK",
+    "DRUID",
+  },
+  WRATH = {
+    "WARRIOR",
+    "PALADIN",
+    "HUNTER",
+    "ROGUE",
+    "PRIEST",
+    "SHAMAN",
+    "MAGE",
+    "WARLOCK",
+    "DRUID",
+    -- Wrath only
+    "DEATHKNIGHT",
+  },
+  RETAIL = {
+    "WARRIOR",
+    "PALADIN",
+    "HUNTER",
+    "ROGUE",
+    "PRIEST",
+    "SHAMAN",
+    "MAGE",
+    "WARLOCK",
+    "DRUID",
+    -- Wrath only
+    "DEATHKNIGHT",
+    -- Retail only
+    "MONK",
+    "DEMONHUNTER",
+    "EVOKER",
+  },
+}

--- a/Core/Requirements.lua
+++ b/Core/Requirements.lua
@@ -69,6 +69,8 @@ function TXUI:CheckRequirements(requirements, skipProfile)
       if not F.IsAddOnEnabled("ElvUI_WindTools") then return requirement end
     elseif requirement == I.Enum.Requirements.OLD_FADE_PERSIST_DISABLED then
       if F.IsAddOnEnabled("ElvUI_GlobalFadePersist") then return requirement end
+    elseif requirement == I.Enum.Requirements.ELVUI_ACTIONBARS_DISABLED then
+      if E.private.actionbar.enable ~= true then return requirement end
     elseif requirement == I.Enum.Requirements.DETAILS_LOADED_AND_TXPROFILE then
       local profileName = F.IsAddOnEnabled("Details") and Details and Details.GetCurrentProfileName and Details.GetCurrentProfileName()
       if not profileName or (profileName ~= I.ProfileNames.Default and profileName ~= I.ProfileNames.Dev) then return requirement end

--- a/Modules/AddOns/FadePersist.lua
+++ b/Modules/AddOns/FadePersist.lua
@@ -50,7 +50,7 @@ function FP:Disable()
 
   self:UnhookAll()
 
-  if self.ab then
+  if E.private.actionbar.enable and self.ab then
     self.ab.fadeParent:GetScript("OnEvent")(self.ab.fadeParent)
     self.ab.fadeParent:RegisterEvent("PLAYER_REGEN_DISABLED")
     self.ab.fadeParent:RegisterEvent("PLAYER_REGEN_ENABLED")
@@ -72,7 +72,7 @@ function FP:Disable()
 end
 
 function FP:Enable()
-  if not self.Initialized then return end
+  if not self.Initialized or not E.private.actionbar.enable then return end
 
   -- Don't unregister for combat or ElvUI mode
   if (self.db.mode ~= "IN_COMBAT") and (self.db.mode ~= "NO_COMBAT") and (self.db.mode ~= "ELVUI") then
@@ -140,7 +140,7 @@ function FP:DatabaseUpdate()
     self:Disable()
 
     -- Enable only out of combat
-    if TXUI:HasRequirements(I.Requirements.FadePersist) and (self.db and self.db.enabled) then self:Enable() end
+    if TXUI:HasRequirements(I.Requirements.FadePersist) and (self.db and self.db.enabled) and E.private.actionbar.enable then self:Enable() end
   end)
 end
 

--- a/Modules/Options/Misc/Others.lua
+++ b/Modules/Options/Misc/Others.lua
@@ -195,7 +195,7 @@ function O:Plugins_Others()
   end
 
   -- ElvUI Global Fade Persist Mode
-  do
+  if E.private.actionbar.enable then
     -- ElvUI Global Fade Persist Group
     local elvuiFadePersistGroup = self:AddInlineRequirementsDesc(options, {
       name = "ActionBar Fade",
@@ -246,10 +246,10 @@ function O:Plugins_Others()
         F.Event.TriggerEvent("FadePersist.DatabaseUpdate")
       end,
     }
-  end
 
-  -- Spacer
-  self:AddSpacer(options)
+    -- Spacer
+    self:AddSpacer(options)
+  end
 
   -- ToxiUI Game Menu Button
   do

--- a/Modules/Options/Misc/Others.lua
+++ b/Modules/Options/Misc/Others.lua
@@ -195,7 +195,8 @@ function O:Plugins_Others()
   end
 
   -- ElvUI Global Fade Persist Mode
-  if E.private.actionbar.enable then
+  local actionBarsAreDisabled = E.private.actionbar.enabled ~= true
+  do
     -- ElvUI Global Fade Persist Group
     local elvuiFadePersistGroup = self:AddInlineRequirementsDesc(options, {
       name = "ActionBar Fade",
@@ -222,7 +223,7 @@ function O:Plugins_Others()
 
     -- Disabled helper
     local optionsDisabled = function()
-      return self:GetEnabledState(E.db.TXUI.addons.fadePersist.enabled, elvuiFadePersistGroup) ~= self.enabledState.YES
+      return actionBarsAreDisabled or self:GetEnabledState(E.db.TXUI.addons.fadePersist.enabled, elvuiFadePersistGroup) ~= self.enabledState.YES
     end
 
     -- Mode
@@ -246,10 +247,10 @@ function O:Plugins_Others()
         F.Event.TriggerEvent("FadePersist.DatabaseUpdate")
       end,
     }
-
-    -- Spacer
-    self:AddSpacer(options)
   end
+
+  -- Spacer
+  self:AddSpacer(options)
 
   -- ToxiUI Game Menu Button
   do

--- a/Modules/Options/Misc/VehicleBar.lua
+++ b/Modules/Options/Misc/VehicleBar.lua
@@ -11,7 +11,6 @@ function O:Plugins_VehicleBar()
     order = self:GetOrder(),
     type = "group",
     name = "VehicleBar",
-    hidden = VehicleBarDisabled,
     get = function(info)
       return E.db.TXUI.vehicleBar[info[#info]]
     end,
@@ -57,7 +56,7 @@ function O:Plugins_VehicleBar()
     }
 
     optionsHidden = function()
-      return self:GetEnabledState(E.db.TXUI.vehicleBar.enabled, generalGroup) ~= self.enabledState.YES
+      return VehicleBarDisabled or self:GetEnabledState(E.db.TXUI.vehicleBar.enabled, generalGroup) ~= self.enabledState.YES
     end
   end
 

--- a/Modules/Options/Misc/VehicleBar.lua
+++ b/Modules/Options/Misc/VehicleBar.lua
@@ -2,11 +2,16 @@ local TXUI, F, E, I, V, P, G = unpack(select(2, ...))
 local O = TXUI:GetModule("Options")
 
 function O:Plugins_VehicleBar()
+  local VehicleBarDisabled = function()
+    return not E.db.TXUI.vehicleBar.enabled or not E.private.actionbar.enable
+  end
+
   -- Create Tab
   self.options.misc.args.vehicleBar = {
     order = self:GetOrder(),
     type = "group",
     name = "VehicleBar",
+    hidden = VehicleBarDisabled,
     get = function(info)
       return E.db.TXUI.vehicleBar[info[#info]]
     end,

--- a/Modules/Plugins/VehicleBar.lua
+++ b/Modules/Plugins/VehicleBar.lua
@@ -238,7 +238,7 @@ function VB:Disable()
 end
 
 function VB:Enable()
-  if not self.Initialized then return end
+  if not self.Initialized and E.private.actionbar.enable then return end
 
   -- Update or create bar
   self:UpdateBar()
@@ -279,7 +279,7 @@ function VB:DatabaseUpdate()
 
   -- Enable only out of combat
   F.Event.ContinueOutOfCombat(function()
-    if TXUI:HasRequirements(I.Requirements.VehicleBar) and (self.db and self.db.enabled) then self:Enable() end
+    if TXUI:HasRequirements(I.Requirements.VehicleBar) and (self.db and self.db.enabled) and E.private.actionbar.enable then self:Enable() end
   end)
 end
 


### PR DESCRIPTION
Closes #54 

# Summary of Changes

1. Fix errors when action bars are disabled by not letting the code register or go into code that relies on ElvUI
2. Hide the sections that are not applicable once ActionBars are disabled from the TX settings menu

# Description

Hides the VehicleBar (because it relies on ElvUI ActionBars being enabled)
Hides Fade behavior from the other tab in misc
Fixes errors

# To test

-   [ ] Disable ActionBars while having fade persist enabled
-   [ ] Check if options are hidden and if there are no errors
