### PR TITLE
Remove the need to forceload the addons

### DIFF
--- a/Core/Changelog/6.4.3.lua
+++ b/Core/Changelog/6.4.3.lua
@@ -12,6 +12,7 @@ TXUI.Changelog["6.4.3"] = {
       .. F.String.Sublist(F.String.Class("Talents Window") .. " (Wrath & Classic only)"),
 
     "* Bug fixes",
+    F.String.ToxiUI .. ": Removed the need to forceload addons when adjusting scale through " .. F.String.ToxiUI("Additional Scaling"),
 
     "* Profile updates",
 

--- a/Core/Changelog/6.4.3.lua
+++ b/Core/Changelog/6.4.3.lua
@@ -12,7 +12,7 @@ TXUI.Changelog["6.4.3"] = {
       .. F.String.Sublist(F.String.Class("Talents Window") .. " (Wrath & Classic only)"),
 
     "* Bug fixes",
-    F.String.ToxiUI .. ": Removed the need to forceload addons when adjusting scale through " .. F.String.ToxiUI("Additional Scaling"),
+    TXUI.Title .. ": Removed the need to forceload addons when adjusting scale through " .. F.String.ToxiUI("Additional Scaling"),
 
     "* Profile updates",
 

--- a/Modules/Misc/AdditionalScaling.lua
+++ b/Modules/Misc/AdditionalScaling.lua
@@ -2,8 +2,6 @@ local TXUI, F, E, I, V, P, G = unpack((select(2, ...)))
 local M = TXUI:GetModule("Misc")
 
 local _G = _G
-local LoadAddOn = LoadAddOn
-local IsAddOnLoaded = IsAddOnLoaded
 local xpcall = xpcall
 
 M.addonsToLoad = {}

--- a/Modules/Misc/AdditionalScaling.lua
+++ b/Modules/Misc/AdditionalScaling.lua
@@ -4,8 +4,38 @@ local M = TXUI:GetModule("Misc")
 local _G = _G
 local LoadAddOn = LoadAddOn
 local IsAddOnLoaded = IsAddOnLoaded
+local xpcall = xpcall
 
-function M:SetElementScale(dbName, blizzName, loadAddonName)
+M.addonsToLoad = {}
+
+function M:AddCallbackForAddon(addonName, func)
+  local addon = M.addonsToLoad[addonName]
+  if not addon then
+    M.addonsToLoad[addonName] = {}
+    addon = M.addonsToLoad[addonName]
+  end
+
+  if type(func) == "string" then func = M[func] end
+
+  tinsert(addon, func or M[addonName])
+end
+
+function M:ADDON_LOADED(_, addonName)
+  if not E.initialized or not TXUI:HasRequirements(I.Requirements.AdditionalScaling) then return end
+
+  local object = M.addonsToLoad[addonName]
+  if object then M:CallLoadedAddon(addonName, object) end
+end
+
+function M:CallLoadedAddon(addonName, object)
+  for _, func in next, object do
+    xpcall(func, print, M)
+  end
+
+  M.addonsToLoad[addonName] = nil
+end
+
+function M:SetElementScale(dbName, blizzName)
   if E.db and E.db.TXUI then
     local option = E.db.TXUI.misc.scaling[dbName]
 
@@ -14,10 +44,7 @@ function M:SetElementScale(dbName, blizzName, loadAddonName)
       return
     end
 
-    if option.scale ~= 1 then
-      if loadAddonName and not IsAddOnLoaded(loadAddonName) then LoadAddOn(loadAddonName) end
-      _G[blizzName]:SetScale(option.scale)
-    end
+    if option.scale ~= 1 then _G[blizzName]:SetScale(option.scale) end
   else
     TXUI:LogDebug("AdditionalScaling > E.db or E.db.TXUI not found, skipping scaling!")
   end
@@ -30,15 +57,27 @@ function M:AdditionalScaling()
   M:SetElementScale("map", "WorldMapFrame")
   M:SetElementScale("characterFrame", "CharacterFrame")
   M:SetElementScale("dressingRoom", "DressUpFrame")
-  -- Special case for synced character & inspect frames
-  local syncedFrameName = E.db.TXUI.misc.scaling.syncInspect.enabled and "characterFrame" or "inspectFrame"
-  M:SetElementScale(syncedFrameName, "InspectFrame", "Blizzard_InspectUI")
+  M:AddCallbackForAddon("Blizzard_InspectUI", "ScaleInspectUI")
 
-  if TXUI.IsRetail then
-    M:SetElementScale("collections", "CollectionsJournal", "Blizzard_Collections")
-    M:SetElementScale("wardrobe", "WardrobeFrame", "Blizzard_Collections")
-  end
-  if not TXUI.IsRetail then M:SetElementScale("talents", "PlayerTalentFrame", "Blizzard_TalentUI") end
+  if TXUI.IsRetail then M:AddCallbackForAddon("Blizzard_Collections", "ScaleCollections") end
+
+  if not TXUI.IsRetail then M:AddCallbackForAddon("Blizzard_TalentUI", "ScaleTalents") end
 end
 
+function M:ScaleCollections()
+  M:SetElementScale("collections", "CollectionsJournal")
+  M:SetElementScale("wardrobe", "WardrobeFrame")
+end
+
+function M:ScaleInspectUI()
+  -- Special case for synced character & inspect frames
+  local syncedFrameName = E.db.TXUI.misc.scaling.syncInspect.enabled and "characterFrame" or "inspectFrame"
+  M:SetElementScale(syncedFrameName, "InspectFrame")
+end
+
+function M:ScaleTalents()
+  M:SetElementScale("talents", "PlayerTalentFrame")
+end
+
+M:RegisterEvent("ADDON_LOADED")
 M:AddCallback("AdditionalScaling")


### PR DESCRIPTION
Closes #66 

# Summary of Changes

1. Removes the need to forceload the addons

# Description

We delay the scale set now until the game itself loads the addons, which in turn is proper usage of the UI

# To test

- [ ] See reproduction steps in #66 
