### PR TITLE
remove the need to reload the ui when adjusting scaling of UI elements

### DIFF
--- a/Core/Changelog/6.4.3.lua
+++ b/Core/Changelog/6.4.3.lua
@@ -13,6 +13,7 @@ TXUI.Changelog["6.4.3"] = {
 
     "* Bug fixes",
     TXUI.Title .. ": Removed the need to forceload addons when adjusting scale through " .. F.String.ToxiUI("Additional Scaling"),
+    TXUI.Title .. ": Removed the need to reload when adjusting scale through " .. F.String.ToxiUI("Additional Scaling"),
 
     "* Profile updates",
 

--- a/Modules/Misc/AdditionalScaling.lua
+++ b/Modules/Misc/AdditionalScaling.lua
@@ -3,6 +3,7 @@ local M = TXUI:GetModule("Misc")
 
 local _G = _G
 local xpcall = xpcall
+local IsAddOnLoaded = IsAddOnLoaded
 
 M.addonsToLoad = {}
 
@@ -55,11 +56,26 @@ function M:AdditionalScaling()
   M:SetElementScale("map", "WorldMapFrame")
   M:SetElementScale("characterFrame", "CharacterFrame")
   M:SetElementScale("dressingRoom", "DressUpFrame")
-  M:AddCallbackForAddon("Blizzard_InspectUI", "ScaleInspectUI")
 
-  if TXUI.IsRetail then M:AddCallbackForAddon("Blizzard_Collections", "ScaleCollections") end
+  -- In the next parts, if the AddOn isn't loaded by the game yet we add it to a list to be loaded as soon as the AddOn has been loaded
+  -- Otherwise we can scale the UI element directly.
+  if not IsAddOnLoaded("Blizzard_InspectUI") then
+    M:AddCallbackForAddon("Blizzard_InspectUI", "ScaleInspectUI")
+  else
+    M:ScaleInspectUI()
+  end
 
-  if not TXUI.IsRetail then M:AddCallbackForAddon("Blizzard_TalentUI", "ScaleTalents") end
+  if TXUI.IsRetail and not IsAddOnLoaded("Blizzard_Collections") then
+    M:AddCallbackForAddon("Blizzard_Collections", "ScaleCollections")
+  else
+    M:ScaleCollections()
+  end
+
+  if not TXUI.IsRetail and not IsAddOnLoaded("Blizzard_TalentUI") then
+    M:AddCallbackForAddon("Blizzard_TalentUI", "ScaleTalents")
+  else
+    M:ScaleTalents()
+  end
 end
 
 function M:ScaleCollections()

--- a/Modules/Options/Misc/AdditionalScaling.lua
+++ b/Modules/Options/Misc/AdditionalScaling.lua
@@ -1,5 +1,6 @@
 local TXUI, F, E, I, V, P, G = unpack((select(2, ...)))
 local O = TXUI:GetModule("Options")
+local Misc = TXUI:GetModule("Misc")
 
 function O:Plugins_AdditionalScaling()
   -- Create Tab
@@ -44,7 +45,7 @@ function O:Plugins_AdditionalScaling()
       end,
       set = function(_, value)
         E.db.TXUI.misc.scaling.characterFrame.scale = value
-        E:StaticPopup_Show("CONFIG_RL")
+        Misc:AdditionalScaling()
       end,
       min = 0.5,
       max = 2,
@@ -60,7 +61,7 @@ function O:Plugins_AdditionalScaling()
       end,
       set = function(_, value)
         E.db.TXUI.misc.scaling.dressingRoom.scale = value
-        E:StaticPopup_Show("CONFIG_RL")
+        Misc:AdditionalScaling()
       end,
       min = 0.5,
       max = 2,
@@ -80,7 +81,7 @@ function O:Plugins_AdditionalScaling()
       end,
       set = function(_, value)
         E.db.TXUI.misc.scaling.inspectFrame.scale = value
-        E:StaticPopup_Show("CONFIG_RL")
+        Misc:AdditionalScaling()
       end,
       min = 0.5,
       max = 2,
@@ -98,8 +99,7 @@ function O:Plugins_AdditionalScaling()
       end,
       set = function(_, value)
         E.db.TXUI.misc.scaling.syncInspect.enabled = value
-
-        E:StaticPopup_Show("CONFIG_RL")
+        Misc:AdditionalScaling()
       end,
     }
   end
@@ -125,7 +125,7 @@ function O:Plugins_AdditionalScaling()
       end,
       set = function(_, value)
         E.db.TXUI.misc.scaling.map.scale = value
-        E:StaticPopup_Show("CONFIG_RL")
+        Misc:AdditionalScaling()
       end,
       min = 0.5,
       max = 2,
@@ -157,7 +157,7 @@ function O:Plugins_AdditionalScaling()
       end,
       set = function(_, value)
         E.db.TXUI.misc.scaling.wardrobe.scale = value
-        E:StaticPopup_Show("CONFIG_RL")
+        Misc:AdditionalScaling()
       end,
       min = 0.5,
       max = 2,
@@ -177,7 +177,7 @@ function O:Plugins_AdditionalScaling()
       end,
       set = function(_, value)
         E.db.TXUI.misc.scaling.collections.scale = value
-        E:StaticPopup_Show("CONFIG_RL")
+        Misc:AdditionalScaling()
       end,
       min = 0.5,
       max = 2,
@@ -206,7 +206,7 @@ function O:Plugins_AdditionalScaling()
       end,
       set = function(_, value)
         E.db.TXUI.misc.scaling.talents.scale = value
-        E:StaticPopup_Show("CONFIG_RL")
+        Misc:AdditionalScaling()
       end,
       min = 0.5,
       max = 2,


### PR DESCRIPTION
# Summary of Changes

1. Makes it so you can adjust scaling without entire UI reload (works in realtime now)

# Description

See summary

# To test

- [ ] Start the game
- [ ] Adjust scaling of characterwindow
- [ ] Open characterwindow and see scale be different
- [ ] Adjust scaling once again
- [ ] It should update in realtime
