### PR TITLE
Fix teleport items that became toys in wrath patch

### DIFF
--- a/Core/Changelog/6.4.4.lua
+++ b/Core/Changelog/6.4.4.lua
@@ -8,7 +8,8 @@ TXUI.Changelog["6.4.4"] = {
     "* New features",
 
     "* Bug fixes",
-    TXUI.Title .. ": WunderBar LFG fix in " .. F.String.ToxiUI("Wrath"),
+    TXUI.Title .. ": Fix WunderBar LFG in " .. F.String.ToxiUI("Wrath"),
+    TXUI.Title .. ": Fix WunderBar Hearthstone toys in " .. F.String.ToxiUI("Wrath"),
 
     "* Profile updates",
     TXUI.Title .. ": Double UI scale for 2054 height screens",

--- a/Core/Functions/Core.lua
+++ b/Core/Functions/Core.lua
@@ -777,7 +777,7 @@ function F.CacheHearthstoneData()
   for id, config in pairs(I.HearthstoneData) do
     if config.load == nil or config.load == true then
       if (config.type == "toy") or (config.type == "item") then
-        if not TXUI.IsRetail and config.type == "toy" then TXUI:ThrowError("HearthstoneData: Type toy is not valid for: " .. id) end
+        if TXUI.IsClassic and config.type == "toy" then TXUI:ThrowError("HearthstoneData: Type toy is not valid for: " .. id) end
 
         local success = F.ProtectedCall(function()
           local itemMixin = CreateFromMixins(ItemMixin)
@@ -786,7 +786,7 @@ function F.CacheHearthstoneData()
             config.id = id
             config.name = itemMixin:GetItemName()
 
-            if TXUI.IsRetail then
+            if not TXUI.IsClassic then
               config.known = (config.type == "item") and true or PlayerHasToy(id)
             else
               config.known = GetItemCount(id, false, true) > 0

--- a/Core/Internal.lua
+++ b/Core/Internal.lua
@@ -462,9 +462,9 @@ I.HearthstoneData = {
 
 I.HearthstoneData_Wrath = {
   [6948] = { ["type"] = "item", ["hearthstone"] = true }, -- Hearthstone
-  [48933] = { ["type"] = "item", ["hearthstone"] = false }, -- Wormhole Generator: Northrend
+  [48933] = { ["type"] = "toy", ["hearthstone"] = false }, -- Wormhole Generator: Northrend
   [54452] = { ["type"] = "item", ["hearthstone"] = true }, -- Ethereal Portal
-  [184871] = { ["type"] = "item", ["hearthstone"] = true }, -- Dark Portal (TBC Deluxe Edition)
+  [184871] = { ["type"] = "toy", ["hearthstone"] = true }, -- Dark Portal (TBC Deluxe Edition)
 
   -- Hearthstone: Death Knight
   [50977] = { ["type"] = "spell", ["hearthstone"] = false, ["class"] = "DEATHKNIGHT" }, -- Death Gate


### PR DESCRIPTION
# Summary of Changes

1. Mark dark portal and wormhole as toys
2. Invert if so that toy logic works on wrath

# Description

see summary

# To test

- [ ] Change hearthstone to wormhole
- [ ] click and seem agic
