### PR TITLE
📦 NEW: Support for Wunderbar top position

### DIFF
--- a/Modules/Options/WunderBar/General.lua
+++ b/Modules/Options/WunderBar/General.lua
@@ -73,6 +73,23 @@ function O:WunderBar_General()
     -- Spacer
     self:AddSpacer(generalGroup["args"])
 
+    -- Position
+    generalGroup["args"]["position"] = {
+      order = self:GetOrder(),
+      type = "select",
+      name = "Position",
+      desc = "Choose whether to display the WunderBar at the top or bottom of the screen.",
+      values = {
+        TOP = "Top",
+        BOTTOM = "Bottom"
+      },
+      get = function(info) return E.db.TXUI.wunderbar.general.position or "BOTTOM" end,
+      set = function(info, value)
+        E.db.TXUI.wunderbar.general.position = value
+        TXUI:GetModule("WunderBar"):UpdateBar()
+      end,
+    }
+
     -- Visibility
     generalGroup["args"]["barVisibility"] = {
       order = self:GetOrder(),

--- a/Modules/WunderBar/Bar.lua
+++ b/Modules/WunderBar/Bar.lua
@@ -92,7 +92,16 @@ function WB:UpdateBar()
   local barHeight = E:Scale(self.db.general.barHeight)
   self.bar:SetSize(F.PerfectScale(self.db.general.barWidth), barHeight)
   self.bar:ClearAllPoints()
-  self.bar:SetPoint("BOTTOM", 0, 0)
+  
+  local position = self.db.general.position or "BOTTOM"
+  local isTop = position == "TOP"
+
+  -- Use the new position setting
+  if isTop then
+    self.bar:SetPoint("TOP", E.UIParent, "TOP", 0, 0)
+  else
+    self.bar:SetPoint("BOTTOM", E.UIParent, "BOTTOM", 0, 0)
+  end
 
   -- Size for modules
   local panelSize = F.PerfectScale(self:CalculateEqualWidth(self.db.general.barWidth, E:Scale(self.db.general.barSpacing)))
@@ -125,18 +134,36 @@ function WB:UpdateBar()
     self:StopAnimationType(self.bar.barBackground, self.animationType.COLOR)
 
     if self.db.general.backgroundGradient then
-      F.Color.SetGradientRGB(
-        self.bar.barBackground,
-        "VERTICAL",
-        color.r,
-        color.g,
-        color.b,
-        color.a,
-        color.r,
-        color.g,
-        color.b,
-        color.a * (1 - self.db.general.backgroundGradientAlpha)
-      )
+      local initialAlpha = color.a
+      local endAlpha = color.a * (1 - self.db.general.backgroundGradientAlpha)
+
+      if isTop then
+        F.Color.SetGradientRGB(
+          self.bar.barBackground,
+          "VERTICAL",
+          color.r,
+          color.g,
+          color.b,
+          endAlpha,
+          color.r,
+          color.g,
+          color.b,
+          initialAlpha
+        )
+        else
+        F.Color.SetGradientRGB(
+          self.bar.barBackground,
+          "VERTICAL",
+          color.r,
+          color.g,
+          color.b,
+          initialAlpha,
+          color.r,
+          color.g,
+          color.b,
+          endAlpha
+        )
+        end
     else
       F.Color.SetGradientRGB(self.bar.barBackground, "VERTICAL", color.r, color.g, color.b, color.a, color.r, color.g, color.b, color.a)
     end

--- a/Modules/WunderBar/SubModules/DataBar.lua
+++ b/Modules/WunderBar/SubModules/DataBar.lua
@@ -354,7 +354,10 @@ function DB:UpdatePosition()
   self.barIcon:SetPoint("RIGHT", self.bar, "LEFT", -iconPadding, iconOffset)
 
   self.infoText:ClearAllPoints()
-  self.infoText:SetPoint("CENTER", self.bar, "CENTER", 0, self.db.infoOffset)
+  local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
+  local infoOffset = isTop and -self.db.general.infoOffset or self.db.infoOffset
+  self.infoText:SetPoint("CENTER", 0, infoOffset)
+
 
   self.bar.completedOverlay:ClearAllPoints()
   self.bar.completedOverlay:SetAllPoints(self.bar)

--- a/Modules/WunderBar/SubModules/MicroMenu.lua
+++ b/Modules/WunderBar/SubModules/MicroMenu.lua
@@ -416,7 +416,10 @@ function MM:UpdateIcons()
       -- Info Text
       if frame.infoText then
         WB:SetFontFromDB(self.db.general, "info", frame.infoText, true, self.db.general.infoUseAccent)
-        frame.infoText:SetPoint("CENTER", 0, self.db.general.infoOffset)
+
+        local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
+        local infoOffset = isTop and -self.db.general.infoOffset or self.db.general.infoOffset
+        frame.infoText:SetPoint("CENTER", 0, infoOffset)
 
         if self.db.general.infoEnabled then
           frame.infoText:Show()

--- a/Modules/WunderBar/SubModules/SpecSwitch.lua
+++ b/Modules/WunderBar/SubModules/SpecSwitch.lua
@@ -344,7 +344,10 @@ function SS:UpdatePosition()
   secondaryIcon:SetPoint("RIGHT", secondaryText, "LEFT", -iconPadding, iconOffset - 0)
 
   self.infoText:ClearAllPoints()
-  self.infoText:SetPoint("CENTER", secondaryText, "CENTER", 0, self.db.general.infoOffset)
+  local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
+  local infoOffset = isTop and -self.db.general.infoOffset or self.db.general.infoOffset
+  self.infoText:SetPoint("CENTER", secondaryText, "CENTER", 0, infoOffset)
+
 
   if not self.forceHideSpec2 and (self.spec1 and self.spec2) then
     local totalWidth = (primaryText:GetStringWidth() + iconSpace)

--- a/Modules/WunderBar/SubModules/Time.lua
+++ b/Modules/WunderBar/SubModules/Time.lua
@@ -268,7 +268,9 @@ function TI:UpdateClock()
   self.colon:SetPoint("CENTER", self.frame, "CENTER", 0, self.db.textOffset)
 
   self.infoText:ClearAllPoints()
-  self.infoText:SetPoint("CENTER", self.colon, "CENTER", 0, self.db.infoOffset)
+  local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
+  local infoOffset = isTop and -self.db.infoOffset or self.db.infoOffset
+  self.infoText:SetPoint("CENTER", self.colon, "CENTER", 0, infoOffset)
 
   if self.showRestingAnimation then
     local _, fontSize = self.minutes:GetFont()


### PR DESCRIPTION
# Summary of Changes

I like to have the info bars at the top, so, I needed to have the Wunderbar in the top of the screen after migrating to ToxiUI 

1. Ability to show the Wunderbar at the top of the screen

# Description

Works great. I've fixed the things that I've noticed, but I am not a ToxiUI hardcore user, so I could be missing some cases.

**New config**
![Screenshot 2024-09-26 at 11 00 36](https://github.com/user-attachments/assets/d40c4f7e-edab-4a40-8989-c48678fb48ec)

# Demo

**Top**

![Screenshot 2024-09-26 at 11 01 30](https://github.com/user-attachments/assets/bcb37afc-9b19-4a38-a3f6-d6ec9e750b29)

**Bottom**

![Screenshot 2024-09-26 at 11 09 01](https://github.com/user-attachments/assets/f8fc91c7-0418-4b57-8869-328c3ac991eb)


# To test

- [ ] Change the Wunderbar position in its General config.
