### PR TITLE
📦 NEW: Support for Wunderbar top position (#138)

### DIFF
--- a/Core/Changelog/6.8.4.lua
+++ b/Core/Changelog/6.8.4.lua
@@ -6,6 +6,7 @@ TXUI.Changelog["6.8.4"] = {
     "* Breaking changes",
 
     "* New features",
+    F.String.Menu.WunderBar() .. " can now be positioned at the top >.>" .. F.String.Sublist("Credits to arturogutierrez"),
 
     "* Bug fixes",
     "Fix currency sorting issue where currencies would go under the wrong expansion header",

--- a/Core/Profile.lua
+++ b/Core/Profile.lua
@@ -762,6 +762,8 @@ P.wunderbar = {
   general = {
     enabled = true,
 
+    position = "BOTTOM",
+
     experimentalDynamicSize = true,
 
     animations = true,

--- a/Modules/Options/WunderBar/General.lua
+++ b/Modules/Options/WunderBar/General.lua
@@ -73,6 +73,23 @@ function O:WunderBar_General()
     -- Spacer
     self:AddSpacer(generalGroup["args"])
 
+    -- Position
+    generalGroup["args"]["position"] = {
+      order = self:GetOrder(),
+      type = "select",
+      name = "Position",
+      desc = "Choose whether to display the WunderBar at the top or bottom of the screen.",
+      values = {
+        TOP = "Top",
+        BOTTOM = "Bottom"
+      },
+      get = function(info) return E.db.TXUI.wunderbar.general.position or "BOTTOM" end,
+      set = function(info, value)
+        E.db.TXUI.wunderbar.general.position = value
+        TXUI:GetModule("WunderBar"):UpdateBar()
+      end,
+    }
+
     -- Visibility
     generalGroup["args"]["barVisibility"] = {
       order = self:GetOrder(),

--- a/Modules/Options/WunderBar/General.lua
+++ b/Modules/Options/WunderBar/General.lua
@@ -78,7 +78,7 @@ function O:WunderBar_General()
       order = self:GetOrder(),
       type = "select",
       name = "Position",
-      desc = "Choose whether to display the WunderBar at the top or bottom of the screen.",
+      desc = "Choose whether to display the " .. F.String.Menu.WunderBar() .. " at the top or bottom of the screen.",
       values = {
         TOP = "Top",
         BOTTOM = "Bottom",

--- a/Modules/Options/WunderBar/General.lua
+++ b/Modules/Options/WunderBar/General.lua
@@ -81,13 +81,8 @@ function O:WunderBar_General()
       desc = "Choose whether to display the WunderBar at the top or bottom of the screen.",
       values = {
         TOP = "Top",
-        BOTTOM = "Bottom"
+        BOTTOM = "Bottom",
       },
-      get = function(info) return E.db.TXUI.wunderbar.general.position or "BOTTOM" end,
-      set = function(info, value)
-        E.db.TXUI.wunderbar.general.position = value
-        TXUI:GetModule("WunderBar"):UpdateBar()
-      end,
     }
 
     -- Visibility

--- a/Modules/WunderBar/Bar.lua
+++ b/Modules/WunderBar/Bar.lua
@@ -92,7 +92,16 @@ function WB:UpdateBar()
   local barHeight = E:Scale(self.db.general.barHeight)
   self.bar:SetSize(F.PerfectScale(self.db.general.barWidth), barHeight)
   self.bar:ClearAllPoints()
-  self.bar:SetPoint("BOTTOM", 0, 0)
+  
+  local position = self.db.general.position or "BOTTOM"
+  local isTop = position == "TOP"
+
+  -- Use the new position setting
+  if isTop then
+    self.bar:SetPoint("TOP", E.UIParent, "TOP", 0, 0)
+  else
+    self.bar:SetPoint("BOTTOM", E.UIParent, "BOTTOM", 0, 0)
+  end
 
   -- Size for modules
   local panelSize = F.PerfectScale(self:CalculateEqualWidth(self.db.general.barWidth, E:Scale(self.db.general.barSpacing)))
@@ -125,18 +134,36 @@ function WB:UpdateBar()
     self:StopAnimationType(self.bar.barBackground, self.animationType.COLOR)
 
     if self.db.general.backgroundGradient then
-      F.Color.SetGradientRGB(
-        self.bar.barBackground,
-        "VERTICAL",
-        color.r,
-        color.g,
-        color.b,
-        color.a,
-        color.r,
-        color.g,
-        color.b,
-        color.a * (1 - self.db.general.backgroundGradientAlpha)
-      )
+      local initialAlpha = color.a
+      local endAlpha = color.a * (1 - self.db.general.backgroundGradientAlpha)
+
+      if isTop then
+        F.Color.SetGradientRGB(
+          self.bar.barBackground,
+          "VERTICAL",
+          color.r,
+          color.g,
+          color.b,
+          endAlpha,
+          color.r,
+          color.g,
+          color.b,
+          initialAlpha
+        )
+        else
+        F.Color.SetGradientRGB(
+          self.bar.barBackground,
+          "VERTICAL",
+          color.r,
+          color.g,
+          color.b,
+          initialAlpha,
+          color.r,
+          color.g,
+          color.b,
+          endAlpha
+        )
+        end
     else
       F.Color.SetGradientRGB(self.bar.barBackground, "VERTICAL", color.r, color.g, color.b, color.a, color.r, color.g, color.b, color.a)
     end

--- a/Modules/WunderBar/Bar.lua
+++ b/Modules/WunderBar/Bar.lua
@@ -134,14 +134,10 @@ function WB:UpdateBar()
     self:StopAnimationType(self.bar.barBackground, self.animationType.COLOR)
 
     if self.db.general.backgroundGradient then
-      local initialAlpha = color.a
-      local endAlpha = color.a * (1 - self.db.general.backgroundGradientAlpha)
+      local initialAlpha = isTop and color.a * (1 - self.db.general.backgroundGradientAlpha) or color.a
+      local endAlpha = isTop and color.a or color.a * (1 - self.db.general.backgroundGradientAlpha)
 
-      if isTop then
-        F.Color.SetGradientRGB(self.bar.barBackground, "VERTICAL", color.r, color.g, color.b, endAlpha, color.r, color.g, color.b, initialAlpha)
-      else
-        F.Color.SetGradientRGB(self.bar.barBackground, "VERTICAL", color.r, color.g, color.b, initialAlpha, color.r, color.g, color.b, endAlpha)
-      end
+      F.Color.SetGradientRGB(self.bar.barBackground, "VERTICAL", color.r, color.g, color.b, initialAlpha, color.r, color.g, color.b, endAlpha)
     else
       F.Color.SetGradientRGB(self.bar.barBackground, "VERTICAL", color.r, color.g, color.b, color.a, color.r, color.g, color.b, color.a)
     end

--- a/Modules/WunderBar/Bar.lua
+++ b/Modules/WunderBar/Bar.lua
@@ -93,11 +93,7 @@ function WB:UpdateBar()
   self.bar:SetSize(F.PerfectScale(self.db.general.barWidth), barHeight)
   self.bar:ClearAllPoints()
 
-  local position = self.db.general.position or "BOTTOM"
-  local isTop = position == "TOP"
-
-  -- Use the new position setting
-  if isTop then
+  if self.isTop then
     self.bar:SetPoint("TOP", E.UIParent, "TOP", 0, 0)
   else
     self.bar:SetPoint("BOTTOM", E.UIParent, "BOTTOM", 0, 0)
@@ -134,8 +130,8 @@ function WB:UpdateBar()
     self:StopAnimationType(self.bar.barBackground, self.animationType.COLOR)
 
     if self.db.general.backgroundGradient then
-      local initialAlpha = isTop and color.a * (1 - self.db.general.backgroundGradientAlpha) or color.a
-      local endAlpha = isTop and color.a or color.a * (1 - self.db.general.backgroundGradientAlpha)
+      local initialAlpha = self.isTop and color.a * (1 - self.db.general.backgroundGradientAlpha) or color.a
+      local endAlpha = self.isTop and color.a or color.a * (1 - self.db.general.backgroundGradientAlpha)
 
       F.Color.SetGradientRGB(self.bar.barBackground, "VERTICAL", color.r, color.g, color.b, initialAlpha, color.r, color.g, color.b, endAlpha)
     else

--- a/Modules/WunderBar/Bar.lua
+++ b/Modules/WunderBar/Bar.lua
@@ -92,7 +92,7 @@ function WB:UpdateBar()
   local barHeight = E:Scale(self.db.general.barHeight)
   self.bar:SetSize(F.PerfectScale(self.db.general.barWidth), barHeight)
   self.bar:ClearAllPoints()
-  
+
   local position = self.db.general.position or "BOTTOM"
   local isTop = position == "TOP"
 
@@ -138,32 +138,10 @@ function WB:UpdateBar()
       local endAlpha = color.a * (1 - self.db.general.backgroundGradientAlpha)
 
       if isTop then
-        F.Color.SetGradientRGB(
-          self.bar.barBackground,
-          "VERTICAL",
-          color.r,
-          color.g,
-          color.b,
-          endAlpha,
-          color.r,
-          color.g,
-          color.b,
-          initialAlpha
-        )
-        else
-        F.Color.SetGradientRGB(
-          self.bar.barBackground,
-          "VERTICAL",
-          color.r,
-          color.g,
-          color.b,
-          initialAlpha,
-          color.r,
-          color.g,
-          color.b,
-          endAlpha
-        )
-        end
+        F.Color.SetGradientRGB(self.bar.barBackground, "VERTICAL", color.r, color.g, color.b, endAlpha, color.r, color.g, color.b, initialAlpha)
+      else
+        F.Color.SetGradientRGB(self.bar.barBackground, "VERTICAL", color.r, color.g, color.b, initialAlpha, color.r, color.g, color.b, endAlpha)
+      end
     else
       F.Color.SetGradientRGB(self.bar.barBackground, "VERTICAL", color.r, color.g, color.b, color.a, color.r, color.g, color.b, color.a)
     end

--- a/Modules/WunderBar/Core.lua
+++ b/Modules/WunderBar/Core.lua
@@ -137,8 +137,6 @@ function WB:DatabaseUpdate()
 
   -- Set db
   self.db = F.GetDBFromPath("TXUI.wunderbar")
-  self.isTop = self.db.general.position == "TOP"
-  self.dirMulti = self.isTop and -1 or 1
 
   if not self.Initialized then return end
 
@@ -151,6 +149,8 @@ end
 function WB:Construct()
   -- Set db
   self.db = F.GetDBFromPath("TXUI.wunderbar")
+  self.isTop = self.db.general.position == "TOP"
+  self.dirMulti = self.isTop and -1 or 1
 
   -- Register ElvUI & LDB DataText
   self:RegisterElvUIDatatexts()

--- a/Modules/WunderBar/Core.lua
+++ b/Modules/WunderBar/Core.lua
@@ -137,6 +137,8 @@ function WB:DatabaseUpdate()
 
   -- Set db
   self.db = F.GetDBFromPath("TXUI.wunderbar")
+  self.isTop = self.db.general.position == "TOP"
+  self.dirMulti = self.isTop and -1 or 1
 
   if not self.Initialized then return end
 

--- a/Modules/WunderBar/SecureFlyOut.lua
+++ b/Modules/WunderBar/SecureFlyOut.lua
@@ -22,9 +22,6 @@ function WB:ShowSecureFlyOut(parent, direction, primarySlots, secondarySlots)
   local dirLeft = direction == "LEFT"
   local dirRight = direction == "RIGHT"
 
-  -- For reversing Y offset basically
-  local dirMulti = dirDown and -1 or 1
-
   if InCombatLockdown() then return end
 
   local function getSpellID(button)
@@ -169,12 +166,12 @@ function WB:ShowSecureFlyOut(parent, direction, primarySlots, secondarySlots)
 
     if indexInColumn == 1 then
       -- First slot in the column
-      slot:SetPoint(dirDown and "TOPRIGHT" or "BOTTOMRIGHT", secureFlyOutFrame, dirDown and "TOPRIGHT" or "BOTTOMRIGHT", -columnOffset, dirMulti * padding)
+      slot:SetPoint(dirDown and "TOPRIGHT" or "BOTTOMRIGHT", secureFlyOutFrame, dirDown and "TOPRIGHT" or "BOTTOMRIGHT", -columnOffset, self.dirMulti * padding)
       prevSlots[currentColumn] = slot
     else
       -- Subsequent slots, positioned above the previous slot in the same column
       -- Ensure the slot is positioned correctly with respect to spacing and the slot above it
-      slot:SetPoint(dirDown and "TOP" or "BOTTOM", prevSlots[currentColumn], dirDown and "BOTTOM" or "TOP", 0, dirMulti * spacing)
+      slot:SetPoint(dirDown and "TOP" or "BOTTOM", prevSlots[currentColumn], dirDown and "BOTTOM" or "TOP", 0, self.dirMulti * spacing)
       prevSlots[currentColumn] = slot
     end
 

--- a/Modules/WunderBar/SecureFlyOut.lua
+++ b/Modules/WunderBar/SecureFlyOut.lua
@@ -22,6 +22,9 @@ function WB:ShowSecureFlyOut(parent, direction, primarySlots, secondarySlots)
   local dirLeft = direction == "LEFT"
   local dirRight = direction == "RIGHT"
 
+  -- For reversing Y offset basically
+  local dirMulti = dirDown and -1 or 1
+
   if InCombatLockdown() then return end
 
   local function getSpellID(button)
@@ -166,12 +169,12 @@ function WB:ShowSecureFlyOut(parent, direction, primarySlots, secondarySlots)
 
     if indexInColumn == 1 then
       -- First slot in the column
-      slot:SetPoint(dirDown and "TOPRIGHT" or "BOTTOMRIGHT", secureFlyOutFrame, dirDown and "TOPRIGHT" or "BOTTOMRIGHT", -columnOffset, self.dirMulti * padding)
+      slot:SetPoint(dirDown and "TOPRIGHT" or "BOTTOMRIGHT", secureFlyOutFrame, dirDown and "TOPRIGHT" or "BOTTOMRIGHT", -columnOffset, dirMulti * padding)
       prevSlots[currentColumn] = slot
     else
       -- Subsequent slots, positioned above the previous slot in the same column
       -- Ensure the slot is positioned correctly with respect to spacing and the slot above it
-      slot:SetPoint(dirDown and "TOP" or "BOTTOM", prevSlots[currentColumn], dirDown and "BOTTOM" or "TOP", 0, self.dirMulti * spacing)
+      slot:SetPoint(dirDown and "TOP" or "BOTTOM", prevSlots[currentColumn], dirDown and "BOTTOM" or "TOP", 0, dirMulti * spacing)
       prevSlots[currentColumn] = slot
     end
 

--- a/Modules/WunderBar/SecureFlyOut.lua
+++ b/Modules/WunderBar/SecureFlyOut.lua
@@ -174,7 +174,7 @@ function WB:ShowSecureFlyOut(parent, direction, primarySlots, secondarySlots)
     else
       -- Subsequent slots, positioned above the previous slot in the same column
       -- Ensure the slot is positioned correctly with respect to spacing and the slot above it
-      slot:SetPoint(dirDown and "TOP" or "BOTTOM", prevSlots[currentColumn], dirDown and "BOTTOM" or "TOP", 0, dirDown and dirMulti * spacing)
+      slot:SetPoint(dirDown and "TOP" or "BOTTOM", prevSlots[currentColumn], dirDown and "BOTTOM" or "TOP", 0, dirMulti * spacing)
       prevSlots[currentColumn] = slot
     end
 

--- a/Modules/WunderBar/SecureFlyOut.lua
+++ b/Modules/WunderBar/SecureFlyOut.lua
@@ -17,6 +17,14 @@ function WB:ShowSecureFlyOut(parent, direction, primarySlots, secondarySlots)
     return
   end
 
+  local dirUp = direction == "UP"
+  local dirDown = direction == "DOWN"
+  local dirLeft = direction == "LEFT"
+  local dirRight = direction == "RIGHT"
+
+  -- For reversing Y offset basically
+  local dirMulti = dirDown and -1 or 1
+
   if InCombatLockdown() then return end
 
   local function getSpellID(button)
@@ -161,14 +169,12 @@ function WB:ShowSecureFlyOut(parent, direction, primarySlots, secondarySlots)
 
     if indexInColumn == 1 then
       -- First slot in the column
-      -- I don't fucking know how I got here to this calc but I think it makes sense, basically position the column
-      -- based on all the columns, then add 4:3 ratio padding and add border because icons have borders /shrug
-      slot:SetPoint("BOTTOMRIGHT", secureFlyOutFrame, "BOTTOMRIGHT", -columnOffset, padding)
+      slot:SetPoint(dirDown and "TOPRIGHT" or "BOTTOMRIGHT", secureFlyOutFrame, dirDown and "TOPRIGHT" or "BOTTOMRIGHT", -columnOffset, dirMulti * padding)
       prevSlots[currentColumn] = slot
     else
       -- Subsequent slots, positioned above the previous slot in the same column
       -- Ensure the slot is positioned correctly with respect to spacing and the slot above it
-      slot:SetPoint("BOTTOM", prevSlots[currentColumn], "TOP", 0, spacing)
+      slot:SetPoint(dirDown and "TOP" or "BOTTOM", prevSlots[currentColumn], dirDown and "BOTTOM" or "TOP", 0, dirDown and dirMulti * spacing)
       prevSlots[currentColumn] = slot
     end
 
@@ -257,13 +263,13 @@ function WB:ShowSecureFlyOut(parent, direction, primarySlots, secondarySlots)
   secureFlyOutFrame:SetFrameStrata("DIALOG")
   secureFlyOutFrame:ClearAllPoints()
 
-  if direction == "UP" then
+  if dirUp then
     secureFlyOutFrame:SetPoint("BOTTOMRIGHT", parent, "TOPRIGHT")
-  elseif direction == "DOWN" then
-    secureFlyOutFrame:SetPoint("TOP", parent, "BOTTOM")
-  elseif direction == "LEFT" then
+  elseif dirDown then
+    secureFlyOutFrame:SetPoint("TOPRIGHT", parent, "BOTTOMRIGHT")
+  elseif dirLeft then
     secureFlyOutFrame:SetPoint("RIGHT", parent, "LEFT")
-  elseif direction == "RIGHT" then
+  elseif dirRight then
     secureFlyOutFrame:SetPoint("LEFT", parent, "RIGHT")
   end
 

--- a/Modules/WunderBar/SubModules/DataBar.lua
+++ b/Modules/WunderBar/SubModules/DataBar.lua
@@ -354,8 +354,8 @@ function DB:UpdatePosition()
   self.barIcon:SetPoint("RIGHT", self.bar, "LEFT", -iconPadding, iconOffset)
 
   self.infoText:ClearAllPoints()
-  local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
-  local infoOffset = isTop and -self.db.general.infoOffset or self.db.infoOffset
+  local isTop = E.db.TXUI.wunderbar.general.position == "TOP"
+  local infoOffset = isTop and -self.db.infoOffset or self.db.infoOffset
   self.infoText:SetPoint("CENTER", 0, infoOffset)
 
   self.bar.completedOverlay:ClearAllPoints()

--- a/Modules/WunderBar/SubModules/DataBar.lua
+++ b/Modules/WunderBar/SubModules/DataBar.lua
@@ -358,7 +358,6 @@ function DB:UpdatePosition()
   local infoOffset = isTop and -self.db.general.infoOffset or self.db.infoOffset
   self.infoText:SetPoint("CENTER", 0, infoOffset)
 
-
   self.bar.completedOverlay:ClearAllPoints()
   self.bar.completedOverlay:SetAllPoints(self.bar)
 end

--- a/Modules/WunderBar/SubModules/DataBar.lua
+++ b/Modules/WunderBar/SubModules/DataBar.lua
@@ -354,8 +354,7 @@ function DB:UpdatePosition()
   self.barIcon:SetPoint("RIGHT", self.bar, "LEFT", -iconPadding, iconOffset)
 
   self.infoText:ClearAllPoints()
-  local isTop = E.db.TXUI.wunderbar.general.position == "TOP"
-  self.infoText:SetPoint("CENTER", 0, (isTop and -1 or 1) * self.db.infoOffset)
+  self.infoText:SetPoint("CENTER", 0, WB.dirMulti * self.db.infoOffset)
 
   self.bar.completedOverlay:ClearAllPoints()
   self.bar.completedOverlay:SetAllPoints(self.bar)

--- a/Modules/WunderBar/SubModules/DataBar.lua
+++ b/Modules/WunderBar/SubModules/DataBar.lua
@@ -355,8 +355,7 @@ function DB:UpdatePosition()
 
   self.infoText:ClearAllPoints()
   local isTop = E.db.TXUI.wunderbar.general.position == "TOP"
-  local infoOffset = isTop and -self.db.infoOffset or self.db.infoOffset
-  self.infoText:SetPoint("CENTER", 0, infoOffset)
+  self.infoText:SetPoint("CENTER", 0, (isTop and -1 or 1) * self.db.infoOffset)
 
   self.bar.completedOverlay:ClearAllPoints()
   self.bar.completedOverlay:SetAllPoints(self.bar)

--- a/Modules/WunderBar/SubModules/DataBar.lua
+++ b/Modules/WunderBar/SubModules/DataBar.lua
@@ -354,7 +354,10 @@ function DB:UpdatePosition()
   self.barIcon:SetPoint("RIGHT", self.bar, "LEFT", -iconPadding, iconOffset)
 
   self.infoText:ClearAllPoints()
-  self.infoText:SetPoint("CENTER", self.bar, "CENTER", 0, self.db.infoOffset)
+  local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
+  local infoOffset = isTop and -self.db.general.infoOffset or self.db.infoOffset
+  self.infoText:SetPoint("CENTER", 0, infoOffset)
+
 
   self.bar.completedOverlay:ClearAllPoints()
   self.bar.completedOverlay:SetAllPoints(self.bar)

--- a/Modules/WunderBar/SubModules/Hearthstone.lua
+++ b/Modules/WunderBar/SubModules/Hearthstone.lua
@@ -165,7 +165,7 @@ function HS:GetMagePortals()
     end
   end
 
-  WB:ShowSecureFlyOut(self.frame, "UP", teleportList, portalList)
+  WB:ShowSecureFlyOut(self.frame, self.flyoutDirection, teleportList, portalList)
 end
 
 function HS:UpdateSelected()
@@ -228,7 +228,7 @@ function HS:UpdateSelected()
   if self.hsMythics and not F.Table.IsEmpty(self.hsMythics) then
     self.secureFrame:SetAttribute("shift-type1", "function")
     self.secureFrame:SetAttribute("shift-_function1", function()
-      WB:ShowSecureFlyOut(self.frame, "UP", self.hsMythics)
+      WB:ShowSecureFlyOut(self.frame, self.flyoutDirection, self.hsMythics)
     end)
   end
 
@@ -486,6 +486,8 @@ function HS:OnInit()
   -- Create stuff
   self:CreateText()
   self:OnWunderBarUpdate()
+
+  self.flyoutDirection = E.db.TXUI.wunderbar.general.position == "TOP" and "DOWN" or "UP"
 
   -- We are done, hooray!
   self.Initialized = true

--- a/Modules/WunderBar/SubModules/Hearthstone.lua
+++ b/Modules/WunderBar/SubModules/Hearthstone.lua
@@ -427,7 +427,8 @@ function HS:UpdateElements()
   end
 
   self.hearthstoneIcon:SetPoint("RIGHT", self.hearthstoneText, "LEFT", -5, 3)
-  self.hearthstoneText.cooldownText:SetPoint("CENTER", self.hearthstoneText, "CENTER", 0, self.db.cooldownOffset)
+  local isTop = E.db.TXUI.wunderbar.general.position == "TOP"
+  self.hearthstoneText.cooldownText:SetPoint("CENTER", self.hearthstoneText, "CENTER", 0, (isTop and -1 or 1) * self.db.cooldownOffset)
 
   if self.db.showIcon then
     self.hearthstoneIcon:Show()

--- a/Modules/WunderBar/SubModules/Hearthstone.lua
+++ b/Modules/WunderBar/SubModules/Hearthstone.lua
@@ -427,8 +427,7 @@ function HS:UpdateElements()
   end
 
   self.hearthstoneIcon:SetPoint("RIGHT", self.hearthstoneText, "LEFT", -5, 3)
-  local isTop = E.db.TXUI.wunderbar.general.position == "TOP"
-  self.hearthstoneText.cooldownText:SetPoint("CENTER", self.hearthstoneText, "CENTER", 0, (isTop and -1 or 1) * self.db.cooldownOffset)
+  self.hearthstoneText.cooldownText:SetPoint("CENTER", self.hearthstoneText, "CENTER", 0, WB.dirMulti * self.db.cooldownOffset)
 
   if self.db.showIcon then
     self.hearthstoneIcon:Show()

--- a/Modules/WunderBar/SubModules/MicroMenu.lua
+++ b/Modules/WunderBar/SubModules/MicroMenu.lua
@@ -417,9 +417,7 @@ function MM:UpdateIcons()
       if frame.infoText then
         WB:SetFontFromDB(self.db.general, "info", frame.infoText, true, self.db.general.infoUseAccent)
 
-        local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
-        local infoOffset = isTop and -self.db.general.infoOffset or self.db.general.infoOffset
-        frame.infoText:SetPoint("CENTER", 0, infoOffset)
+        frame.infoText:SetPoint("CENTER", 0, WB.dirMulti * self.db.general.infoOffset)
 
         if self.db.general.infoEnabled then
           frame.infoText:Show()

--- a/Modules/WunderBar/SubModules/MicroMenu.lua
+++ b/Modules/WunderBar/SubModules/MicroMenu.lua
@@ -416,7 +416,10 @@ function MM:UpdateIcons()
       -- Info Text
       if frame.infoText then
         WB:SetFontFromDB(self.db.general, "info", frame.infoText, true, self.db.general.infoUseAccent)
-        frame.infoText:SetPoint("CENTER", 0, self.db.general.infoOffset)
+
+        local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
+        local infoOffset = isTop and -self.db.general.infoOffset or self.db.general.infoOffset
+        frame.infoText:SetPoint("CENTER", 0, infoOffset)
 
         if self.db.general.infoEnabled then
           frame.infoText:Show()

--- a/Modules/WunderBar/SubModules/Profession.lua
+++ b/Modules/WunderBar/SubModules/Profession.lua
@@ -106,7 +106,8 @@ function PR:ProfessionClick(prof, frame, button)
       end
     end
 
-    WB:ShowSecureFlyOut(frame, "UP", menuList)
+    local flyoutDirection = E.db.TXUI.wunderbar.general.position == "TOP" and "DOWN" or "UP"
+    WB:ShowSecureFlyOut(frame, flyoutDirection, menuList)
   else
     self:ProfessionOpen(prof)
   end

--- a/Modules/WunderBar/SubModules/SpecSwitch.lua
+++ b/Modules/WunderBar/SubModules/SpecSwitch.lua
@@ -348,7 +348,6 @@ function SS:UpdatePosition()
   local infoOffset = isTop and -self.db.general.infoOffset or self.db.general.infoOffset
   self.infoText:SetPoint("CENTER", secondaryText, "CENTER", 0, infoOffset)
 
-
   if not self.forceHideSpec2 and (self.spec1 and self.spec2) then
     local totalWidth = (primaryText:GetStringWidth() + iconSpace)
     totalWidth = totalWidth + (secondaryText:GetStringWidth() + iconSpace)

--- a/Modules/WunderBar/SubModules/SpecSwitch.lua
+++ b/Modules/WunderBar/SubModules/SpecSwitch.lua
@@ -174,7 +174,8 @@ function SS:SpecClick(frame, button, ...)
         end
       end
 
-      WB:ShowSecureFlyOut(frame, "UP", menuList)
+      local flyoutDirection = E.db.TXUI.wunderbar.general.position == "TOP" and "DOWN" or "UP"
+      WB:ShowSecureFlyOut(frame, flyoutDirection, menuList)
     end
   end
 end

--- a/Modules/WunderBar/SubModules/SpecSwitch.lua
+++ b/Modules/WunderBar/SubModules/SpecSwitch.lua
@@ -344,7 +344,10 @@ function SS:UpdatePosition()
   secondaryIcon:SetPoint("RIGHT", secondaryText, "LEFT", -iconPadding, iconOffset - 0)
 
   self.infoText:ClearAllPoints()
-  self.infoText:SetPoint("CENTER", secondaryText, "CENTER", 0, self.db.general.infoOffset)
+  local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
+  local infoOffset = isTop and -self.db.general.infoOffset or self.db.general.infoOffset
+  self.infoText:SetPoint("CENTER", secondaryText, "CENTER", 0, infoOffset)
+
 
   if not self.forceHideSpec2 and (self.spec1 and self.spec2) then
     local totalWidth = (primaryText:GetStringWidth() + iconSpace)

--- a/Modules/WunderBar/SubModules/SpecSwitch.lua
+++ b/Modules/WunderBar/SubModules/SpecSwitch.lua
@@ -345,9 +345,7 @@ function SS:UpdatePosition()
   secondaryIcon:SetPoint("RIGHT", secondaryText, "LEFT", -iconPadding, iconOffset - 0)
 
   self.infoText:ClearAllPoints()
-  local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
-  local infoOffset = isTop and -self.db.general.infoOffset or self.db.general.infoOffset
-  self.infoText:SetPoint("CENTER", secondaryText, "CENTER", 0, infoOffset)
+  self.infoText:SetPoint("CENTER", secondaryText, "CENTER", 0, WB.dirMulti * self.db.general.infoOffset)
 
   if not self.forceHideSpec2 and (self.spec1 and self.spec2) then
     local totalWidth = (primaryText:GetStringWidth() + iconSpace)

--- a/Modules/WunderBar/SubModules/Time.lua
+++ b/Modules/WunderBar/SubModules/Time.lua
@@ -268,7 +268,9 @@ function TI:UpdateClock()
   self.colon:SetPoint("CENTER", self.frame, "CENTER", 0, self.db.textOffset)
 
   self.infoText:ClearAllPoints()
-  self.infoText:SetPoint("CENTER", self.colon, "CENTER", 0, self.db.infoOffset)
+  local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
+  local infoOffset = isTop and -self.db.infoOffset or self.db.infoOffset
+  self.infoText:SetPoint("CENTER", self.colon, "CENTER", 0, infoOffset)
 
   if self.showRestingAnimation then
     local _, fontSize = self.minutes:GetFont()

--- a/Modules/WunderBar/SubModules/Time.lua
+++ b/Modules/WunderBar/SubModules/Time.lua
@@ -268,9 +268,7 @@ function TI:UpdateClock()
   self.colon:SetPoint("CENTER", self.frame, "CENTER", 0, self.db.textOffset)
 
   self.infoText:ClearAllPoints()
-  local isTop = (WB.db.general.position or "BOTTOM") == "TOP"
-  local infoOffset = isTop and -self.db.infoOffset or self.db.infoOffset
-  self.infoText:SetPoint("CENTER", self.colon, "CENTER", 0, infoOffset)
+  self.infoText:SetPoint("CENTER", self.colon, "CENTER", 0, WB.dirMulti * self.db.infoOffset)
 
   if self.showRestingAnimation then
     local _, fontSize = self.minutes:GetFont()


### PR DESCRIPTION
# Notes
- Recreation of https://github.com/Toxicom/toxiui/pull/138

# Summary of Changes

I like to have the info bars at the top, so, I needed to have the Wunderbar in the top of the screen after migrating to ToxiUI 

1. Ability to show the Wunderbar at the top of the screen

# Description

Works great. I've fixed the things that I've noticed, but I am not a ToxiUI hardcore user, so I could be missing some cases.

**New config**
![Screenshot 2024-09-26 at 11 00 36](https://github.com/user-attachments/assets/d40c4f7e-edab-4a40-8989-c48678fb48ec)

# Demo

**Top**

![Screenshot 2024-09-26 at 11 01 30](https://github.com/user-attachments/assets/bcb37afc-9b19-4a38-a3f6-d6ec9e750b29)

**Bottom**

![Screenshot 2024-09-26 at 11 09 01](https://github.com/user-attachments/assets/f8fc91c7-0418-4b57-8869-328c3ac991eb)


# To test

- [ ] Change the Wunderbar position in its General config.