### PR TITLE
Remove player name from login message

### DIFF
--- a/Modules/Changelog/Core.lua
+++ b/Modules/Changelog/Core.lua
@@ -80,9 +80,7 @@ function CL:Initialize()
 
   -- Login Message
   if E.db.general.loginmessage then
-    local msg = "Hello, "
-      .. UnitName("Player")
-      .. ". Welcome to "
+    local msg = "Welcome to "
       .. TXUI.Title
       .. " "
       .. versionString


### PR DESCRIPTION
Removing player name from login message to prevent chat keyword notifications when logging in.

# Summary of Changes

1. Removes the `Hello, <PLAYER NAME>.` from the login message.

# Description
If you have Keyword Alerts enabled in Chat it can be annoying to hear the alert every time you login or reload your UI. This just removes the part that would trigger that for your name.

# To test
- [ ] Login and look at chat.
