### PR TITLE
M+ History

### DIFF
--- a/Core/Profile.lua
+++ b/Core/Profile.lua
@@ -258,6 +258,7 @@ P.addons = {
     showTips = true,
     showCollections = TXUI.IsRetail,
     showMythic = TXUI.IsRetail,
+    historyLimit = 4,
 
     specIconStyle = "ToxiSpecStylized",
     specIconSize = 20,

--- a/Core/Profile.lua
+++ b/Core/Profile.lua
@@ -258,7 +258,7 @@ P.addons = {
     showTips = true,
     showCollections = TXUI.IsRetail,
     showMythic = TXUI.IsRetail,
-    historyLimit = 4,
+    mythicHistoryLimit = 4,
 
     specIconStyle = "ToxiSpecStylized",
     specIconSize = 20,

--- a/Modules/Misc/GameMenuButton.lua
+++ b/Modules/Misc/GameMenuButton.lua
@@ -147,15 +147,14 @@ function M:GameMenuButton()
       local historyLimit = E.db.TXUI.addons.gameMenuSkin.historyLimit
 
       for i = 1, historyLimit do
-        local id = "history" .. i
-        mythic[id] = backgroundFade:CreateFontString(nil, "OVERLAY")
-        mythic[id]:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
-        mythic[id]:SetTextColor(1, 1, 1, 1)
+        mythic["history" .. i] = backgroundFade:CreateFontString(nil, "OVERLAY")
+        mythic["history" .. i]:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
+        mythic["history" .. i]:SetTextColor(1, 1, 1, 1)
 
         if i == 1 then
-          mythic[id]:SetPoint("TOPLEFT", mythic, "BOTTOMLEFT", 0, -24)
+          mythic["history" .. i]:SetPoint("TOPLEFT", mythic, "BOTTOMLEFT", 0, -24)
         else
-          mythic[id]:SetPoint("TOPLEFT", mythic["history" .. (i - 1)], "BOTTOMLEFT", 0, -4)
+          mythic["history" .. i]:SetPoint("TOPLEFT", mythic["history" .. (i - 1)], "BOTTOMLEFT", 0, -4)
         end
       end
 
@@ -213,13 +212,12 @@ function M:GameMenuButton()
       if self.mythic then
         -- Update M+ history
         local history = C_MythicPlus.GetRunHistory(false, true)
-        local total = #history
         local historyLimit = E.db.TXUI.addons.gameMenuSkin.historyLimit
 
-        for i = 1, historyLimit do -- this could be configurable
+        for i = 1, historyLimit do
           local historyFrame = self.mythic["history" .. i]
           if historyFrame then
-            local historyRun = history[total - i + 1]
+            local historyRun = history[#history - i + 1]
             local historyText
             local historyTextPrefix = i .. ": "
             if historyRun then

--- a/Modules/Misc/GameMenuButton.lua
+++ b/Modules/Misc/GameMenuButton.lua
@@ -220,15 +220,12 @@ function M:GameMenuButton()
       if self.mythic then
         -- Update M+ history
         local history = C_MythicPlus.GetRunHistory(false)
-
-        table.sort(history, function(a, b)
-          return a.completedTimestamp > b.completedTimestamp
-        end)
+        local total = #history
 
         for i = 1, 4 do -- this could be configurable
           local historyFrame = self.mythic["history" .. i]
           if historyFrame then
-            local historyRun = history[i]
+            local historyRun = history[total - i + 1]
             local historyText
             local historyTextPrefix = i .. ": "
             if historyRun then

--- a/Modules/Misc/GameMenuButton.lua
+++ b/Modules/Misc/GameMenuButton.lua
@@ -144,7 +144,7 @@ function M:GameMenuButton()
       mythic:SetText(F.String.GradientClass("Mythic+"))
 
       -- Mythic+ history
-      local historyLimit = E.db.TXUI.addons.gameMenuSkin.historyLimit
+      local historyLimit = E.db.TXUI.addons.gameMenuSkin.mythicHistoryLimit
 
       for i = 1, historyLimit do
         mythic["history" .. i] = backgroundFade:CreateFontString(nil, "OVERLAY")
@@ -212,19 +212,18 @@ function M:GameMenuButton()
       if self.mythic then
         -- Update M+ history
         local history = C_MythicPlus.GetRunHistory(false, true)
-        local historyLimit = E.db.TXUI.addons.gameMenuSkin.historyLimit
+        local historyLimit = E.db.TXUI.addons.gameMenuSkin.mythicHistoryLimit
 
         for i = 1, historyLimit do
           local historyFrame = self.mythic["history" .. i]
           if historyFrame then
             local historyRun = history[#history - i + 1]
             local historyText
-            local historyTextPrefix = i .. ": "
+            local historyTextPrefix = i .. ". "
             if historyRun then
               local historyDungeonName = C_ChallengeMode.GetMapUIInfo(historyRun.mapChallengeModeID)
-              historyText = historyRun.completed and
-                  F.String.Good(("%s (+%d)"):format(historyDungeonName, historyRun.level)) or
-                  F.String.Error(("%s (+%d)"):format(historyDungeonName, historyRun.level))
+              historyText = (historyRun.completed and F.String.Good or F.String.Error)(("%s (+%d)"):format(
+                historyDungeonName, historyRun.level))
             else
               historyText = F.String.ToxiUI("N/A")
             end

--- a/Modules/Misc/GameMenuButton.lua
+++ b/Modules/Misc/GameMenuButton.lua
@@ -219,7 +219,7 @@ function M:GameMenuButton()
 
       if self.mythic then
         -- Update M+ history
-        local history = C_MythicPlus.GetRunHistory(false)
+        local history = C_MythicPlus.GetRunHistory(false, true)
         local total = #history
 
         for i = 1, 4 do -- this could be configurable
@@ -230,9 +230,11 @@ function M:GameMenuButton()
             local historyTextPrefix = i .. ": "
             if historyRun then
               local historyDungeonName = C_ChallengeMode.GetMapUIInfo(historyRun.mapChallengeModeID)
-              historyText = ("%s (+%d)"):format(historyDungeonName, historyRun.level)
+              historyText = historyRun.completed and
+                  F.String.Good(("%s (+%d)"):format(historyDungeonName, historyRun.level)) or
+                  F.String.Error(("%s (+%d)"):format(historyDungeonName, historyRun.level))
             else
-              historyText = "N/A"
+              historyText = F.String.ToxiUI("N/A")
             end
 
             historyFrame:SetText(historyTextPrefix .. F.String.ToxiUI(historyText))

--- a/Modules/Misc/GameMenuButton.lua
+++ b/Modules/Misc/GameMenuButton.lua
@@ -144,33 +144,26 @@ function M:GameMenuButton()
       mythic:SetText(F.String.GradientClass("Mythic+"))
 
       -- Mythic+ history
-      mythic.history1 = backgroundFade:CreateFontString(nil, "OVERLAY")
-      mythic.history1:SetPoint("TOPLEFT", mythic, "BOTTOMLEFT", 0, -24)
-      mythic.history1:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
-      mythic.history1:SetTextColor(1, 1, 1, 1)
-      mythic.history1:SetText("1: " .. F.String.ToxiUI("N/A"))
+      local historyLimit = E.db.TXUI.addons.gameMenuSkin.historyLimit
 
-      mythic.history2 = backgroundFade:CreateFontString(nil, "OVERLAY")
-      mythic.history2:SetPoint("TOPLEFT", mythic.history1, "BOTTOMLEFT", 0, -4)
-      mythic.history2:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
-      mythic.history2:SetTextColor(1, 1, 1, 1)
-      mythic.history2:SetText("2: " .. F.String.ToxiUI("N/A"))
+      for i = 1, historyLimit do
+        local id = "history" .. i
+        mythic[id] = backgroundFade:CreateFontString(nil, "OVERLAY")
+        mythic[id]:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
+        mythic[id]:SetTextColor(1, 1, 1, 1)
 
-      mythic.history3 = backgroundFade:CreateFontString(nil, "OVERLAY")
-      mythic.history3:SetPoint("TOPLEFT", mythic.history2, "BOTTOMLEFT", 0, -4)
-      mythic.history3:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
-      mythic.history3:SetTextColor(1, 1, 1, 1)
-      mythic.history3:SetText("3: " .. F.String.ToxiUI("N/A"))
+        if i == 1 then
+          mythic[id]:SetPoint("TOPLEFT", mythic, "BOTTOMLEFT", 0, -24)
+        else
+          mythic[id]:SetPoint("TOPLEFT", mythic["history" .. (i - 1)], "BOTTOMLEFT", 0, -4)
+        end
+      end
 
-      mythic.history4 = backgroundFade:CreateFontString(nil, "OVERLAY")
-      mythic.history4:SetPoint("TOPLEFT", mythic.history3, "BOTTOMLEFT", 0, -4)
-      mythic.history4:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
-      mythic.history4:SetTextColor(1, 1, 1, 1)
-      mythic.history4:SetText("4: " .. F.String.ToxiUI("N/A"))
+
 
       -- Mythic+ keystone
       mythic.keystone = backgroundFade:CreateFontString(nil, "OVERLAY")
-      mythic.keystone:SetPoint("TOPLEFT", mythic.history4, "BOTTOMLEFT", 0, -12)
+      mythic.keystone:SetPoint("TOPLEFT", mythic["history" .. historyLimit], "BOTTOMLEFT", 0, -12)
       mythic.keystone:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
       mythic.keystone:SetTextColor(1, 1, 1, 1)
     end
@@ -221,8 +214,9 @@ function M:GameMenuButton()
         -- Update M+ history
         local history = C_MythicPlus.GetRunHistory(false, true)
         local total = #history
+        local historyLimit = E.db.TXUI.addons.gameMenuSkin.historyLimit
 
-        for i = 1, 4 do -- this could be configurable
+        for i = 1, historyLimit do -- this could be configurable
           local historyFrame = self.mythic["history" .. i]
           if historyFrame then
             local historyRun = history[total - i + 1]

--- a/Modules/Misc/GameMenuButton.lua
+++ b/Modules/Misc/GameMenuButton.lua
@@ -51,7 +51,8 @@ function M:GameMenuButton()
       backgroundFade.bottomText:Point("BOTTOM", 0, 100)
       backgroundFade.bottomText:SetFont(primaryFont, F.FontSizeScaled(14), "OUTLINE")
       backgroundFade.bottomText:SetTextColor(1, 1, 1, 0.6)
-      backgroundFade.bottomText:SetText("You can find all the relevant " .. TXUI.Title .. " information at " .. I.Strings.Branding.Links.Website)
+      backgroundFade.bottomText:SetText("You can find all the relevant " ..
+        TXUI.Title .. " information at " .. I.Strings.Branding.Links.Website)
 
       -- Player Name
       backgroundFade.nameText = backgroundFade:CreateFontString(nil, "OVERLAY")
@@ -142,9 +143,34 @@ function M:GameMenuButton()
       mythic:SetTextColor(1, 1, 1, 1)
       mythic:SetText(F.String.GradientClass("Mythic+"))
 
-      -- Mythic+ Keystone
+      -- Mythic+ history
+      mythic.history1 = backgroundFade:CreateFontString(nil, "OVERLAY")
+      mythic.history1:SetPoint("TOPLEFT", mythic, "BOTTOMLEFT", 0, -24)
+      mythic.history1:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
+      mythic.history1:SetTextColor(1, 1, 1, 1)
+      mythic.history1:SetText("1: " .. F.String.ToxiUI("N/A"))
+
+      mythic.history2 = backgroundFade:CreateFontString(nil, "OVERLAY")
+      mythic.history2:SetPoint("TOPLEFT", mythic.history1, "BOTTOMLEFT", 0, -4)
+      mythic.history2:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
+      mythic.history2:SetTextColor(1, 1, 1, 1)
+      mythic.history2:SetText("2: " .. F.String.ToxiUI("N/A"))
+
+      mythic.history3 = backgroundFade:CreateFontString(nil, "OVERLAY")
+      mythic.history3:SetPoint("TOPLEFT", mythic.history2, "BOTTOMLEFT", 0, -4)
+      mythic.history3:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
+      mythic.history3:SetTextColor(1, 1, 1, 1)
+      mythic.history3:SetText("3: " .. F.String.ToxiUI("N/A"))
+
+      mythic.history4 = backgroundFade:CreateFontString(nil, "OVERLAY")
+      mythic.history4:SetPoint("TOPLEFT", mythic.history3, "BOTTOMLEFT", 0, -4)
+      mythic.history4:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
+      mythic.history4:SetTextColor(1, 1, 1, 1)
+      mythic.history4:SetText("4: " .. F.String.ToxiUI("N/A"))
+
+      -- Mythic+ keystone
       mythic.keystone = backgroundFade:CreateFontString(nil, "OVERLAY")
-      mythic.keystone:SetPoint("TOPLEFT", mythic, "BOTTOMLEFT", 0, -24)
+      mythic.keystone:SetPoint("TOPLEFT", mythic.history4, "BOTTOMLEFT", 0, -12)
       mythic.keystone:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
       mythic.keystone:SetTextColor(1, 1, 1, 1)
     end
@@ -179,22 +205,51 @@ function M:GameMenuButton()
         self.backgroundFade.specIcon:SetFont(iconsFont, F.FontSizeScaled(E.db.TXUI.addons.gameMenuSkin.specIconSize), "")
         self.backgroundFade.specIcon:SetTextColor(1, 1, 1, 1)
 
-        self.backgroundFade.guildText:SetText(guildName and F.String.FastGradientHex("<" .. guildName .. ">", "06c910", "33ff3d") or "")
+        self.backgroundFade.guildText:SetText(guildName and
+          F.String.FastGradientHex("<" .. guildName .. ">", "06c910", "33ff3d") or "")
         self.backgroundFade.specIcon:SetText(specIcon)
         self.backgroundFade.levelText:SetText("Lv " .. E.mylevel)
         self.backgroundFade.classText:SetText(F.String.GradientClass(E.myLocalizedClass, nil, true))
       end
 
-      if self.collections then self.collections.achievs:SetText("Achievement Points: " .. F.String.ToxiUI(E:FormatLargeNumber(GetTotalAchievementPoints(), ","))) end
+      if self.collections then
+        self.collections.achievs:SetText("Achievement Points: " ..
+          F.String.ToxiUI(E:FormatLargeNumber(GetTotalAchievementPoints(), ",")))
+      end
 
       if self.mythic then
+        -- Update M+ history
+        local history = C_MythicPlus.GetRunHistory(false)
+
+        table.sort(history, function(a, b)
+          return a.completedTimestamp > b.completedTimestamp
+        end)
+
+        for i = 1, 4 do -- this could be configurable
+          local historyFrame = self.mythic["history" .. i]
+          if historyFrame then
+            local historyRun = history[i]
+            local historyText
+            local historyTextPrefix = i .. ": "
+            if historyRun then
+              local historyDungeonName = C_ChallengeMode.GetMapUIInfo(historyRun.mapChallengeModeID)
+              historyText = ("%s (+%d)"):format(historyDungeonName, historyRun.level)
+            else
+              historyText = "N/A"
+            end
+
+            historyFrame:SetText(historyTextPrefix .. F.String.ToxiUI(historyText))
+          end
+        end
+
         -- Update keystone text
         local keystoneMapID = C_MythicPlus.GetOwnedKeystoneChallengeMapID()
         local keystoneLevel = C_MythicPlus.GetOwnedKeystoneLevel()
         local keystoneTextPrefix = "Current Keystone: "
         if keystoneMapID and keystoneMapID > 0 then
           local keystoneDungeonName = C_ChallengeMode.GetMapUIInfo(keystoneMapID)
-          self.mythic.keystone:SetText(keystoneTextPrefix .. F.String.ToxiUI(("%s (+%d)"):format(keystoneDungeonName, keystoneLevel)))
+          self.mythic.keystone:SetText(keystoneTextPrefix ..
+            F.String.ToxiUI(("%s (+%d)"):format(keystoneDungeonName, keystoneLevel)))
         else
           self.mythic.keystone:SetText(keystoneTextPrefix .. F.String.ToxiUI("N/A"))
         end
@@ -210,29 +265,32 @@ function M:GameMenuButton()
         local randomTip = randomTips[randomIndex]
 
         local monthDate = date("%m/%d") -- mm/dd eg 10/24 (oct 24)
-        local year = date("%Y") -- yyyy eg 2023
+        local year = date("%Y")         -- yyyy eg 2023
         local ToxiBirthday = monthDate == "01/06"
         local ToxiUiBirthday = monthDate == "10/18"
         local ToxiUiAge = year - 2020
         local holidays = { ["12/24"] = true, ["12/25"] = true, ["12/26"] = true }
-        local holidayString = holidays[monthDate] and "\n\nThe " .. TXUI.Title .. " team wishes you Happy Holidays!" or ""
+        local holidayString = holidays[monthDate] and "\n\nThe " .. TXUI.Title .. " team wishes you Happy Holidays!" or
+            ""
         -- let's call it an easter egg
         if ToxiBirthday then
           self.backgroundFade.tipText:SetText(
             "Did you know that today, January 6th, is "
-              .. F.String.ToxiUI("Toxi")
-              .. "'s birthday?\n"
-              .. F.String.ToxiUI("Fun fact:")
-              .. " First version of the "
-              .. TXUI.Title
-              .. " installer was released on this day back in 2021!"
+            .. F.String.ToxiUI("Toxi")
+            .. "'s birthday?\n"
+            .. F.String.ToxiUI("Fun fact:")
+            .. " First version of the "
+            .. TXUI.Title
+            .. " installer was released on this day back in 2021!"
           )
         elseif ToxiUiBirthday then
           self.backgroundFade.tipText:SetText(
-            "Did you know that today, October 18th, is " .. TXUI.Title .. "'s birthday? " .. TXUI.Title .. " is now " .. ToxiUiAge .. " years old!"
+            "Did you know that today, October 18th, is " ..
+            TXUI.Title .. "'s birthday? " .. TXUI.Title .. " is now " .. ToxiUiAge .. " years old!"
           )
         else
-          self.backgroundFade.tipText:SetText(F.String.ToxiUI("Random tip #" .. randomIndex .. ": ") .. randomTip .. holidayString)
+          self.backgroundFade.tipText:SetText(F.String.ToxiUI("Random tip #" .. randomIndex .. ": ") ..
+            randomTip .. holidayString)
         end
       end
 

--- a/Modules/Options/Skins/GameMenuSkin.lua
+++ b/Modules/Options/Skins/GameMenuSkin.lua
@@ -17,7 +17,8 @@ function O:Skins_ElvUI()
     local mainGroup = self:AddInlineRequirementsDesc(options, {
       name = "Description",
     }, {
-      name = TXUI.Title .. " provides a skin for the Game Menu (ESC) that applies a background and additional information, all of which can be configured here.\n\n",
+      name = TXUI.Title ..
+          " provides a skin for the Game Menu (ESC) that applies a background and additional information, all of which can be configured here.\n\n",
     }, I.Requirements.GameMenuButton).args
 
     -- ToxiUI Game Menu Button Enable
@@ -44,9 +45,10 @@ function O:Skins_ElvUI()
     local backgroundGroup = self:AddInlineRequirementsDesc(options, {
       name = "Background",
     }, {
-      name = "Customize the color of the Game Menu Skin's background.\n\nThe " .. F.String.ToxiUI("Class Color") .. " option will override the " .. F.String.ToxiUI(
-        "Background Color"
-      ) .. " option, but you can still use it to control the alpha of the background.\n\n",
+      name = "Customize the color of the Game Menu Skin's background.\n\nThe " ..
+          F.String.ToxiUI("Class Color") .. " option will override the " .. F.String.ToxiUI(
+            "Background Color"
+          ) .. " option, but you can still use it to control the alpha of the background.\n\n",
     }, I.Requirements.GameMenuButton).args
 
     local optionsDisabled = function()
@@ -85,7 +87,8 @@ function O:Skins_ElvUI()
     local infoGroup = self:AddInlineRequirementsDesc(options, {
       name = "Information Sections",
     }, {
-      name = TXUI.Title .. " Game Menu Skin provides various useful information about your current session. You can choose what to display here.\n\n",
+      name = TXUI.Title ..
+          " Game Menu Skin provides various useful information about your current session. You can choose what to display here.\n\n",
     }, I.Requirements.GameMenuButton).args
 
     local optionsDisabled = function()
@@ -152,6 +155,24 @@ function O:Skins_ElvUI()
         E:StaticPopup_Show("CONFIG_RL")
       end,
       disabled = optionsDisabled,
+      hidden = not TXUI.IsRetail,
+    }
+
+    infoGroup.historyLimit = {
+      order = self:GetOrder(),
+      type = "range",
+      name = "History Limit",
+      desc = "Number of Mythic+ dungeons shown in the history list.",
+      min = 1,
+      max = 10,
+      step = 1,
+      get = function()
+        return E.db.TXUI.addons.gameMenuSkin.historyLimit
+      end,
+      set = function(_, value)
+        E.db.TXUI.addons.gameMenuSkin.historyLimit = value
+      end,
+      disabled = optionsDisabled and not E.db.TXUI.addons.gameMenuSkin.showMythic,
       hidden = not TXUI.IsRetail,
     }
   end

--- a/Modules/Options/Skins/GameMenuSkin.lua
+++ b/Modules/Options/Skins/GameMenuSkin.lua
@@ -1,5 +1,6 @@
 local TXUI, F, E, I, V, P, G = unpack((select(2, ...)))
 local O = TXUI:GetModule("Options")
+local ACR = LibStub("AceConfigRegistry-3.0")
 
 function O:Skins_ElvUI()
   -- Create Tab
@@ -152,13 +153,14 @@ function O:Skins_ElvUI()
       end,
       set = function(_, value)
         E.db.TXUI.addons.gameMenuSkin.showMythic = value
+        ACR:NotifyChange("ToxiUI")
         E:StaticPopup_Show("CONFIG_RL")
       end,
       disabled = optionsDisabled,
       hidden = not TXUI.IsRetail,
     }
 
-    infoGroup.historyLimit = {
+    infoGroup.mythicHistoryLimit = {
       order = self:GetOrder(),
       type = "range",
       name = "History Limit",
@@ -167,12 +169,17 @@ function O:Skins_ElvUI()
       max = 10,
       step = 1,
       get = function()
-        return E.db.TXUI.addons.gameMenuSkin.historyLimit
+        return E.db.TXUI.addons.gameMenuSkin.mythicHistoryLimit
       end,
       set = function(_, value)
-        E.db.TXUI.addons.gameMenuSkin.historyLimit = value
+        E.db.TXUI.addons.gameMenuSkin.mythicHistoryLimit = value
+        ACR:NotifyChange("ToxiUI")
+        E:StaticPopup_Show("CONFIG_RL")
       end,
-      disabled = optionsDisabled and not E.db.TXUI.addons.gameMenuSkin.showMythic,
+      disabled = function()
+        return optionsDisabled()
+            or not E.db.TXUI.addons.gameMenuSkin.showMythic
+      end,
       hidden = not TXUI.IsRetail,
     }
   end


### PR DESCRIPTION
Added M+ History for the last 4 runs.

![image](https://github.com/user-attachments/assets/78fe848a-f802-4d51-b5dd-e54fad5a0903)

Improves #159 

<!-- If needed, link to design -->

# Description 
This adds the last 4 runs to the Game Menu (ESC) screen.  We are unable to pull (to my knowledge) the duration of the key from the history API so the only way to show timers would be to rewrite using raider.io helpers and adding the optional dependency or we could record at the end of the run on the `CHALLENGE_MODE_COMPLETED `  event and store it.

# To test

- [ ] Hit ESC with keys done.