### PR TITLE
Housing teleports

### DIFF
--- a/Core/Functions/Housing.lua
+++ b/Core/Functions/Housing.lua
@@ -2,8 +2,19 @@ local TXUI, F, E, I, V, P, G = unpack((select(2, ...)))
 
 F.Housing = {
   houseInfo = nil, -- cache
+  PlayerHouses = nil,
 }
 
+F.Housing.NeighborhoodMapIndex = {
+    [2352] = 1, --Alliance, Founder's Point
+    [2351] = 2, --Horde, Razorwind Shores
+};
+
+F.Event.RegisterFrameEventAndCallback("PLAYER_HOUSE_LIST_UPDATED", function(_, houseInfos)
+  F.Housing.PlayerHouses = houseInfos
+end, "housing")
+
+    
 function F.Housing:RefreshHouseInfo()
   self.houseInfo = C_Housing.GetCurrentHouseInfo()
   return self.houseInfo
@@ -18,15 +29,9 @@ function F.Housing:GetHouseInfo()
 end
 
 -- Teleport function
-function F.Housing:TeleportHome()
+function F.Housing:TeleportHome(house)
   if not TXUI.IsRetail then
     TXUI:LogDebug("F.Housing.TeleportHome() is Retail only.")
-    return
-  end
-
-  local info = self:GetHouseInfo()
-  if not info then
-    TXUI:LogDebug("F.Housing.TeleportHome >> houseInfo unavailable.")
     return
   end
 
@@ -36,7 +41,19 @@ function F.Housing:TeleportHome()
   --     return
   -- end
 
-  C_Housing.TeleportHome(info.neighborhoodGUID, info.houseGUID, info.plotID)
+  TXUI:LogDebug(house)
+  TXUI.LogDebug("Teleporting to " .. house.houseName)
+  C_Housing.TeleportHome(house.neighborhoodGUID, house.houseGUID, house.plotID)
+end
+
+function F.Housing:GetFactionFromMapIndex(mapIndex)
+  if mapIndex == 1 then
+    return "A"
+  elseif mapIndex == 2 then
+    return "H"
+  else
+    return "???"
+  end
 end
 
 -- Get the name for TeleportHome function
@@ -46,8 +63,7 @@ function F.Housing:GetTeleportHomeName()
     return
   end
 
-  local info = self:GetHouseInfo()
-  if not info then return "DEBUG: No House Info" end
+  if not F.Housing.PlayerHouses then return "DEBUG: No House Info" end
 
   -- if C_HousingNeighborhood.CanReturnAfterVisitingHouse() then
   --   return "Return To Previous Location"

--- a/ElvUI_ToxiUI.toc
+++ b/ElvUI_ToxiUI.toc
@@ -22,3 +22,4 @@ Initialize.lua
 Core\Core.xml
 Media\Media.xml
 Modules\Modules.xml
+Core\Functions\Housing.lua

--- a/Modules/WunderBar/SubModules/Hearthstone.lua
+++ b/Modules/WunderBar/SubModules/Hearthstone.lua
@@ -164,6 +164,26 @@ function HS:GetMagePortals()
   WB:ShowSecureFlyOut(self.frame, self.flyoutDirection, teleportList, portalList)
 end
 
+function HS:GetHouseTeleports()
+  local playerHousingList = {}
+
+  for _, house in F.Table.Sort(F.Housing.PlayerHouses) do
+    local uiMapID = C_Housing.GetUIMapIDForNeighborhood(house.neighborhoodGUID)
+    local mapIndex = uiMapID and F.Housing.NeighborhoodMapIndex[uiMapID] or 1;
+
+    tinsert(playerHousingList, {
+      spellID = 1233637,
+      type = "function",
+      label = F.Housing:GetFaction(mapIndex),
+      func = function()
+        F.Housing:TeleportHome(house)
+      end
+    })
+
+  end
+  WB:ShowSecureFlyOut(self.frame, self.flyoutDirection, playerHousingList)
+end
+
 function HS:UpdateSelected()
   -- Check if everything is loaded
   if not self.dataLoaded then return end
@@ -253,7 +273,7 @@ function HS:UpdateSelected()
     if C_Housing.IsHousingServiceEnabled() then
       self.secureFrame:SetAttribute("ctrl-type1", "function")
       self.secureFrame:SetAttribute("ctrl-_function1", function()
-        F.Housing:TeleportHome()
+        self:GetHouseTeleports()
       end)
     end
   end
@@ -269,14 +289,6 @@ function HS:UpdateTooltip()
 
   self:AddHearthstoneLine(self.hsPrimary)
   if self.hsPrimary ~= self.hsSecondary and not F.IsAddOnEnabled("TomeOfTeleportation") then self:AddHearthstoneLine(self.hsSecondary) end
-  if TXUI.IsRetail then
-    if C_Housing.IsHousingServiceEnabled() then
-      local teleportSpellId = 1233637
-      local teleportSpell = C_Spell.GetSpellInfo(teleportSpellId)
-
-      self:AddHearthstoneLine(teleportSpell)
-    end
-  end
 
   DT.tooltip:AddLine(" ")
 

--- a/Modules/WunderBar/SubModules/MicroMenu.lua
+++ b/Modules/WunderBar/SubModules/MicroMenu.lua
@@ -357,7 +357,8 @@ MM.microMenu = {
         _G.HousingFramesUtil.ToggleHousingDashboard()
       end,
       RightButton = function()
-        F.Housing:TeleportHome()
+        -- Default to First bought house?
+        F.Housing:TeleportHome(F.Housing.PlayerHouses[1])
       end,
     },
     keyBind = "TOGGLEHOUSINGDASHBOARD",


### PR DESCRIPTION
<!--
Creating the PR.
- Fill the template, add/remove sections as needed.
-->

Closes #198 

<!-- If needed, link to design -->

# Summary of Changes

1. Add flyout to hearthstone menu
2. Add teleport to right click of new housing micro menu

# Description

# To test

- [] Get a house or two
- [] Ctrl-Left Click the hearthstone module
- [] Housing should appear similar to below. A for Alliance, H for Horse (May change the icon to reflect this instead of labelling)

<img width="161" height="158" alt="image" src="https://github.com/user-attachments/assets/24718d89-155b-478a-b71b-9c1282160ae7" />


