### PR TITLE
✨ FEAT: add support for The Burning Crusade Anniversary edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,27 @@
-# ToxiUI v7.0.9 - 2025-12-06
+# ToxiUI v7.0.9 - 2026-01-05
 
 ## 🚀 New Features
 
-- Add **Teleport Home** functions to the Hearthstone and MicroMenu modules in the **WunderBar**
-  - Currently, the *"Return To Previous Location"* functionality is being tainted, so it cannot be implemented.
+- Bring back Skyriding Bar for the **ToxiUI Vehicle Bar**
+  - Now uses spell charges from _Skyward Ascent_ instead of the old vigor bar
+  - Displays current spell charges with smooth animations
+  - Configurable textures for Normal, Gradient, and Dark modes
+  - Custom gradient color options (defaults to class color gradient)
+  - Speed Text now has additional customization options
+- Difficulty display and total player count in the Raid Info Frame
 
 ## 🐛 Bug Fixes
 
 - Remove right-click from SpecSwitch module in Classic Era
+- Potentially fix disappearing Vehicle Bar empty buttons
+- Add `InCombatLockdown` protection for Additional Scaling modules
+- Fix **WunderBar MicroMenu** Character info right-click
+
+## 🧩 Profile Updates
+
+- **ElvUI**: Adjust Raid 1 visibility state
+
+## 📘 Documentation
+
+- Update for Mists of Pandaria patch 5.5.3
+- Increase minimum required **ElvUI** version to `14.05`

--- a/Core/Changelog/7.0.9.lua
+++ b/Core/Changelog/7.0.9.lua
@@ -3,8 +3,6 @@ local TXUI, F, E, I, V, P, G = unpack((select(2, ...)))
 TXUI.Changelog["7.0.9"] = {
   HOTFIX = true,
   CHANGES = {
-    "* Breaking changes",
-
     "* New features",
     "Bring back Skyriding Bar for "
       .. TXUI.Title
@@ -28,9 +26,5 @@ TXUI.Changelog["7.0.9"] = {
     "* Documentation",
     "Update for Mists of Pandaria 5.5.3",
     F.String.MinElv("14.05"),
-
-    "* Settings refactoring",
-
-    "* Development improvements",
   },
 }

--- a/Core/Internal.lua
+++ b/Core/Internal.lua
@@ -20,6 +20,7 @@ I.MaxLevelTable = {
   ["Vanilla"] = 60,
   ["Mists"] = 90,
   ["Mainline"] = 80,
+  ["TBC"] = 70,
 }
 
 I.Fonts = {
@@ -742,6 +743,48 @@ I.HearthstoneData_Vanilla = {
 
   [11416] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "IF" }, -- Portal: Ironforge
   [3562] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "IF" }, -- Teleport: Ironforge
+}
+
+I.HearthstoneData_TBC = {
+  [6948] = { ["type"] = "item", ["hearthstone"] = true }, -- Hearthstone
+
+  -- Hearthstone: Druid
+  [18960] = { ["type"] = "spell", ["hearthstone"] = false, ["class"] = "DRUID" }, -- Teleport: Moonglade
+
+  -- Hearthstone: Shaman
+  [556] = { ["type"] = "spell", ["hearthstone"] = true, ["class"] = "SHAMAN" }, -- Astral Recall
+
+  -- Hearthstone: Mage
+  [10059] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "SW" }, -- Portal: Stormwind
+  [3561] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "SW" }, -- Teleport: Stormwind
+
+  [11417] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "ORG" }, -- Portal: Orgrimmar
+  [3567] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "ORG" }, -- Teleport: Orgrimmar
+
+  [11419] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "DARN" }, -- Portal: Darnassus
+  [3565] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "DARN" }, -- Teleport: Darnassus
+
+  [11420] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "TB" }, -- Portal: Thunder Bluff
+  [3566] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "TB" }, -- Teleport: Thunder Bluff
+
+  [11418] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "UC" }, -- Portal: Undercity
+  [3563] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "UC" }, -- Teleport: Undercity
+
+  [11416] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "IF" }, -- Portal: Ironforge
+  [3562] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "IF" }, -- Teleport: Ironforge
+
+  -- TBC-specific portals/teleports
+  [33691] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "TBC" }, -- Portal: Shattrath - Alliance
+  [33690] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "TBC" }, -- Teleport: Shattrath - Alliance
+
+  [35717] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "TBC" }, -- Portal: Shattrath - Horde
+  [35715] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "TBC" }, -- Teleport: Shattrath - Horde
+
+  [32267] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "SM" }, -- Portal: Silvermoon
+  [32272] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "SM" }, -- Teleport: Silvermoon
+
+  [32266] = { ["type"] = "spell", ["hearthstone"] = false, ["portal"] = true, label = "EXO" }, -- Portal: Exodar
+  [32271] = { ["type"] = "spell", ["hearthstone"] = false, ["teleport"] = true, label = "EXO" }, -- Teleport: Exodar
 }
 
 -- Data for which class or spec has which interrupt spell

--- a/Core/InternalEnum.lua
+++ b/Core/InternalEnum.lua
@@ -87,4 +87,4 @@ I.Enum.ChangelogType = F.Enum { "UPDATE", "HOTFIX" }
 I.Enum.Developers = F.Enum { "TOXI", "RYADA", "RHAP", "JAKE" }
 
 -- Client Flavors
-I.Enum.Flavor = F.Enum { "VANILLA", "MISTS", "RETAIL" }
+I.Enum.Flavor = F.Enum { "VANILLA", "MISTS", "RETAIL", "TBC" }

--- a/ElvUI_ToxiUI_TBC.toc
+++ b/ElvUI_ToxiUI_TBC.toc
@@ -1,0 +1,22 @@
+## Title: |cff1784d1ElvUI|r |cffffffffToxi|r|cff18a8ffUI|r |cffff8000The Burning Crusade Anniversary|r
+## Notes: Minimalistic ElvUI Edit by |cff18a8ffToxi|r
+## Author: Toxi (Toxi#21206)
+## Version: 7.0.9
+## RequiredDeps: ElvUI
+## OptionalDeps: Details, Plater
+## IconTexture: Interface\AddOns\ElvUI_ToxiUI\Media\Backgrounds\Logos\LogoSmall.tga
+## DefaultState: Enabled
+## Interface: 20505
+## X-Interface: 20505
+## X-Flavor: TBC
+## X-WoWI-ID: 25770
+## X-Curse-Project-ID: 676447
+## X-ElvUIVersion: 14.05
+## X-Wago-ID: XrNk5lKa
+## X-GitHash: @project-version@
+## Group: ElvUI
+
+Initialize.lua
+Core\Core.xml
+Media\Media.xml
+Modules\Modules.xml

--- a/Initialize.lua
+++ b/Initialize.lua
@@ -41,6 +41,7 @@ TXUI.Version = GetAddOnMetadata(addonName, "Version")
 TXUI.IsVanilla = TXUI.MetaFlavor == "Vanilla"
 TXUI.IsMists = TXUI.MetaFlavor == "Mists"
 TXUI.IsRetail = TXUI.MetaFlavor == "Mainline"
+TXUI.IsTBC = TXUI.MetaFlavor == "TBC"
 
 -- M+ season for Retail, eg.: df3
 -- see Internal.lua for M+ Hearthstones
@@ -65,6 +66,7 @@ function TXUI:Initialize()
     ["Vanilla"] = I.Enum.Flavor.VANILLA,
     ["Mists"] = I.Enum.Flavor.MISTS,
     ["Mainline"] = I.Enum.Flavor.RETAIL,
+    ["TBC"] = I.Enum.Flavor.TBC,
   }
 
   self.Flavor = flavorMap[self.MetaFlavor] or I.Enum.Flavor.RETAIL
@@ -115,8 +117,8 @@ function TXUI:Initialize()
     return
   end
 
-  -- Check for non Mists, non Retail and non Vanilla
-  if not self.IsRetail and not self.IsMists and not self.IsVanilla then return end
+  -- Check for non Mists, non Retail, non Vanilla, and non TBC
+  if not self.IsRetail and not self.IsMists and not self.IsVanilla and not self.IsTBC then return end
 
   -- Force ElvUI Setup to hide
   E.private.install_complete = E.version
@@ -129,6 +131,11 @@ function TXUI:Initialize()
 
   if self.IsVanilla then
     I.HearthstoneData = I.HearthstoneData_Vanilla
+    I.InterruptSpellMap = I.InterruptSpellMap_Empty
+  end
+
+  if self.IsTBC then
+    I.HearthstoneData = I.HearthstoneData_TBC
     I.InterruptSpellMap = I.InterruptSpellMap_Empty
   end
 


### PR DESCRIPTION
This PR adds support for World of Warcraft: The Burning Crusade Anniversary edition.

## Changes
- Added `ElvUI_ToxiUI_TBC.toc` with interface version 20505
- Added TBC flavor enum to `Core/InternalEnum.lua`
- Added TBC detection and initialization in `Initialize.lua`
- Added TBC max level (70) and hearthstone data in `Core/Internal.lua`
- Includes Shattrath, Silvermoon, and Exodar portals/teleports

## More in-depth testing needed in-game
- [ ] Verified max level is set to 70
- [ ] Verified hearthstone module shows TBC portals