### PR TITLE
Add Played to the GameMenu skin

### DIFF
--- a/Core/Profile.lua
+++ b/Core/Profile.lua
@@ -57,8 +57,8 @@ P.styles = {
 -- Themes
 P.themes = {
   darkMode = {
-    enabled = false, -- Disabled by default
-    transparency = true, -- Enabled by default
+    enabled = false,          -- Disabled by default
+    transparency = true,      -- Enabled by default
     transparencyAlpha = 0.25, -- Alpha of Background
   },
   gradientMode = {
@@ -102,75 +102,75 @@ P.themes = {
     },
 
     reactionColorMap = {
-      [I.Enum.GradientMode.Color.NORMAL] = { -- RIGHT
-        BAD = F.Table.HexToRGB("#d94040"), -- enemy
+      [I.Enum.GradientMode.Color.NORMAL] = {   -- RIGHT
+        BAD = F.Table.HexToRGB("#d94040"),     -- enemy
         NEUTRAL = F.Table.HexToRGB("#dec24a"), -- neutral
-        GOOD = F.Table.HexToRGB("#85d92b"), -- friendly
+        GOOD = F.Table.HexToRGB("#85d92b"),    -- friendly
       },
-      [I.Enum.GradientMode.Color.SHIFT] = { -- LEFT
-        BAD = F.Table.HexToRGB("#c72121"), -- enemy
+      [I.Enum.GradientMode.Color.SHIFT] = {    -- LEFT
+        BAD = F.Table.HexToRGB("#c72121"),     -- enemy
         NEUTRAL = F.Table.HexToRGB("#cf9145"), -- neutral
-        GOOD = F.Table.HexToRGB("#2f9706"), -- friendly
+        GOOD = F.Table.HexToRGB("#2f9706"),    -- friendly
       },
     },
 
     castColorMap = {
-      [I.Enum.GradientMode.Color.NORMAL] = { -- RIGHT
-        DEFAULT = F.Table.HexToRGB("#ffbf00"), -- cast def.
-        NOINTERRUPT = F.Table.HexToRGB("#8f8c8c"), -- cast non.
-        INTERRUPTED = F.Table.HexToRGB("#d94040"), -- cast was stopped
-        INTERRUPTCD = F.Table.HexToRGB("#8591b0"), -- interrupt is on cd, and will not come off cd during cast
+      [I.Enum.GradientMode.Color.NORMAL] = {         -- RIGHT
+        DEFAULT = F.Table.HexToRGB("#ffbf00"),       -- cast def.
+        NOINTERRUPT = F.Table.HexToRGB("#8f8c8c"),   -- cast non.
+        INTERRUPTED = F.Table.HexToRGB("#d94040"),   -- cast was stopped
+        INTERRUPTCD = F.Table.HexToRGB("#8591b0"),   -- interrupt is on cd, and will not come off cd during cast
         INTERRUPTSOON = F.Table.HexToRGB("#de7000"), -- interrupt is on cd, but will be ready inside the cast
       },
-      [I.Enum.GradientMode.Color.SHIFT] = { -- LEFT
-        DEFAULT = F.Table.HexToRGB("#ffad00"), -- cast def.
-        NOINTERRUPT = F.Table.HexToRGB("#737070"), -- cast non.
-        INTERRUPTED = F.Table.HexToRGB("#991f1f"), -- cast was stopped
-        INTERRUPTCD = F.Table.HexToRGB("#4f5c7a"), -- interrupt is on cd, and will not come off cd during cast
+      [I.Enum.GradientMode.Color.SHIFT] = {          -- LEFT
+        DEFAULT = F.Table.HexToRGB("#ffad00"),       -- cast def.
+        NOINTERRUPT = F.Table.HexToRGB("#737070"),   -- cast non.
+        INTERRUPTED = F.Table.HexToRGB("#991f1f"),   -- cast was stopped
+        INTERRUPTCD = F.Table.HexToRGB("#4f5c7a"),   -- interrupt is on cd, and will not come off cd during cast
         INTERRUPTSOON = F.Table.HexToRGB("#8f4700"), -- interrupt is on cd, but will be ready inside the cast
       },
     },
 
     powerColorMap = {
-      [I.Enum.GradientMode.Color.SHIFT] = { -- LEFT
-        ALT_POWER = F.Table.HexToRGB("#264ad1"), -- swap alt
-        MANA = F.Table.HexToRGB("#0040b3"), -- mana
-        RAGE = F.Table.HexToRGB("#cf1717"), -- rage
-        FOCUS = F.Table.HexToRGB("#cf591f"), -- focus
-        ENERGY = F.Table.HexToRGB("#d9721a"), -- energy
+      [I.Enum.GradientMode.Color.SHIFT] = {        -- LEFT
+        ALT_POWER = F.Table.HexToRGB("#264ad1"),   -- swap alt
+        MANA = F.Table.HexToRGB("#0040b3"),        -- mana
+        RAGE = F.Table.HexToRGB("#cf1717"),        -- rage
+        FOCUS = F.Table.HexToRGB("#cf591f"),       -- focus
+        ENERGY = F.Table.HexToRGB("#d9721a"),      -- energy
         RUNIC_POWER = F.Table.HexToRGB("#009cff"), -- runic
-        PAIN = F.Table.HexToRGB("#cccccc"), -- pain
-        FURY = F.Table.HexToRGB("#c414b5"), -- fury
+        PAIN = F.Table.HexToRGB("#cccccc"),        -- pain
+        FURY = F.Table.HexToRGB("#c414b5"),        -- fury
         LUNAR_POWER = F.Table.HexToRGB("#9e4fe8"), -- astral
-        INSANITY = F.Table.HexToRGB("#850ab0"), -- insanity
-        MAELSTROM = F.Table.HexToRGB("#0073ff"), -- maelstrom
+        INSANITY = F.Table.HexToRGB("#850ab0"),    -- insanity
+        MAELSTROM = F.Table.HexToRGB("#0073ff"),   -- maelstrom
       },
 
-      [I.Enum.GradientMode.Color.NORMAL] = { -- RIGHT
-        ALT_POWER = F.Table.HexToRGB("#2175d4"), -- swap alt
-        MANA = F.Table.HexToRGB("#35a4ff"), -- mana
-        RAGE = F.Table.HexToRGB("#ed3333"), -- rage
-        FOCUS = F.Table.HexToRGB("#db753b"), -- focus
-        ENERGY = F.Table.HexToRGB("#ffe169"), -- energy
+      [I.Enum.GradientMode.Color.NORMAL] = {       -- RIGHT
+        ALT_POWER = F.Table.HexToRGB("#2175d4"),   -- swap alt
+        MANA = F.Table.HexToRGB("#35a4ff"),        -- mana
+        RAGE = F.Table.HexToRGB("#ed3333"),        -- rage
+        FOCUS = F.Table.HexToRGB("#db753b"),       -- focus
+        ENERGY = F.Table.HexToRGB("#ffe169"),      -- energy
         RUNIC_POWER = F.Table.HexToRGB("#1cd6ff"), -- runic
-        PAIN = F.Table.HexToRGB("#f5f5f5"), -- pain
-        FURY = F.Table.HexToRGB("#e81ff5"), -- fury
+        PAIN = F.Table.HexToRGB("#f5f5f5"),        -- pain
+        FURY = F.Table.HexToRGB("#e81ff5"),        -- fury
         LUNAR_POWER = F.Table.HexToRGB("#9c54ff"), -- astral
-        INSANITY = F.Table.HexToRGB("#9629bd"), -- insanity
-        MAELSTROM = F.Table.HexToRGB("#0096ff"), -- maelstrom
+        INSANITY = F.Table.HexToRGB("#9629bd"),    -- insanity
+        MAELSTROM = F.Table.HexToRGB("#0096ff"),   -- maelstrom
       },
     },
 
     specialColorMap = {
-      [I.Enum.GradientMode.Color.NORMAL] = { -- RIGHT
+      [I.Enum.GradientMode.Color.NORMAL] = {        -- RIGHT
         DISCONNECTED = F.Table.HexToRGB("#ff6b59"), -- disconnect
-        TAPPED = F.Table.HexToRGB("#a3a6b0"), -- tapped
-        DEAD = F.Table.HexToRGB("#cd001c"), -- dead
+        TAPPED = F.Table.HexToRGB("#a3a6b0"),       -- tapped
+        DEAD = F.Table.HexToRGB("#cd001c"),         -- dead
       },
-      [I.Enum.GradientMode.Color.SHIFT] = { -- LEFT
+      [I.Enum.GradientMode.Color.SHIFT] = {         -- LEFT
         DISCONNECTED = F.Table.HexToRGB("#e85747"), -- disconnect
-        TAPPED = F.Table.HexToRGB("#7d828f"), -- tapped
-        DEAD = F.Table.HexToRGB("#61000e"), -- dead
+        TAPPED = F.Table.HexToRGB("#7d828f"),       -- tapped
+        DEAD = F.Table.HexToRGB("#61000e"),         -- dead
       },
     },
 
@@ -242,7 +242,7 @@ P.addons = {
 
   -- Deconstruct
   deconstruct = {
-    enabled = true, -- Enabled by default
+    enabled = true,         -- Enabled by default
     highlightMode = "DARK", -- DARK by default, possible "NONE", "DARK", "ALPHA"
 
     animations = true,
@@ -271,6 +271,7 @@ P.addons = {
 
     showInfo = true,
     showTips = true,
+    showPlayed = true,
     showCollections = TXUI.IsRetail,
 
     showMythic = TXUI.IsRetail,
@@ -283,7 +284,7 @@ P.addons = {
 
   -- Fade Persist
   fadePersist = {
-    enabled = true, -- Enabled by default
+    enabled = true,     -- Enabled by default
     mode = "MOUSEOVER", -- MOUSEOVER, NO_COMBAT, IN_COMBAT, ELVUI, ALWAYS
     showInVehicles = true,
   },
@@ -350,10 +351,10 @@ P.addons = {
 
   -- Damage Meter (Blizzard)
   damageMeter = {
-    enabled = true, -- Enabled by default
-    icons = true, -- Enabled by default
-    gradients = true, -- Enabled by default (works with any theme)
-    headerFade = true, -- Fade header on mouseover
+    enabled = true,         -- Enabled by default
+    icons = true,           -- Enabled by default
+    gradients = true,       -- Enabled by default (works with any theme)
+    headerFade = true,      -- Fade header on mouseover
     headerFadeMinAlpha = 0, -- Alpha when not hovering
     headerFadeMaxAlpha = 1, -- Alpha when hovering
   },
@@ -506,7 +507,7 @@ P.elvUIIcons = {
   deadIcons = {
     enabled = true, -- Enabled by default
     theme = "TXUI_STYLIZED",
-    size = 28, -- 36 for material/original
+    size = 28,      -- 36 for material/original
     xOffset = 0,
     yOffset = 5,
   },
@@ -514,7 +515,7 @@ P.elvUIIcons = {
   offlineIcons = {
     enabled = true, -- Enabled by default
     theme = "TXUI_STYLIZED",
-    size = 28, -- 36 for material/original
+    size = 28,      -- 36 for material/original
     xOffset = 0,
     yOffset = 5,
   },
@@ -828,7 +829,7 @@ P.armory = {
 
 -- Animations (Retail-only)
 P.animations = {
-  enabled = true, -- Enabled by default
+  enabled = true,     -- Enabled by default
 
   animationsMult = 1, -- Animation speed multiplier, higher than 1 => slower, lower than 1 => faster
 
@@ -953,7 +954,7 @@ P.wunderbar = {
 
     barWidth = E.physicalWidth,
     barHeight = 30,
-    barSpacing = 20, -- spacing from the screen edges, reduces the size of the 3 panels
+    barSpacing = 20,             -- spacing from the screen edges, reduces the size of the 3 panels
     barVisibility = "NO_COMBAT", -- ALWAYS, NO_COMBAT, RESTING
     barMouseOverOnly = false,
 
@@ -1001,9 +1002,9 @@ P.wunderbar = {
   },
   subModules = {
     Time = {
-      localTime = true, -- this should be in sync with ElvUI profile for better tooltips
+      localTime = true,                     -- this should be in sync with ElvUI profile for better tooltips
       twentyFour = GetCurrentRegion() ~= 1, -- sets 24h for everyone, except US
-      timeFormat = "HH:MM", -- valid are HH:MM, H:MM, H:M
+      timeFormat = "HH:MM",                 -- valid are HH:MM, H:MM, H:M
 
       showRestingAnimation = true,
       experimentalDynamicSize = false,
@@ -1034,7 +1035,7 @@ P.wunderbar = {
 
       textColor = true,
       textColorFadeFromNormal = true,
-      textColorLatencyThreshold = 60, -- or above
+      textColorLatencyThreshold = 60,   -- or above
       textColorFramerateThreshold = 60, -- or under
 
       showIcons = true,
@@ -1117,14 +1118,14 @@ P.wunderbar = {
 
       displayedCurrency = "GOLD", -- NEEDS to be GOLD
       enabledCurrencies = {
-        [3008] = true, --               Valorstones
-        [3290] = true, --     Gilded Ethereal Crest
-        [3288] = true, --      Runed Ethereal Crest
-        [3286] = true, --     Carved Ethereal Crest
-        [3284] = true, --  Weathered Ethereal Crest
-        [2815] = true, --        Resonance Crystals
-        [3028] = true, --       Restored Coffer Key
-      }, -- Format: [currencyID] = true,
+        [3008] = true,            --               Valorstones
+        [3290] = true,            --     Gilded Ethereal Crest
+        [3288] = true,            --      Runed Ethereal Crest
+        [3286] = true,            --     Carved Ethereal Crest
+        [3284] = true,            --  Weathered Ethereal Crest
+        [2815] = true,            --        Resonance Crystals
+        [3028] = true,            --       Restored Coffer Key
+      },                          -- Format: [currencyID] = true,
 
       showIcon = true,
       showSmall = true,
@@ -1190,8 +1191,8 @@ P.wunderbar = {
         useUppercase = true,
 
         showIcons = true,
-        showSpec1 = true, -- active spec
-        showSpec2 = false, -- loot spec
+        showSpec1 = true,   -- active spec
+        showSpec2 = false,  -- loot spec
 
         showLoadout = true, -- Retail only, show current selected talent loadout
 

--- a/Modules/Misc/GameMenuButton.lua
+++ b/Modules/Misc/GameMenuButton.lua
@@ -4,6 +4,238 @@ local M = TXUI:GetModule("Misc")
 local CreateFrame = CreateFrame
 local GameMenuFrame = GameMenuFrame
 
+-- Spacing helper available across init and show hook
+local function m(num)
+  return num * 4
+end
+
+local function FormatPlayed(seconds, colorize)
+  if not seconds or seconds <= 0 then return "N/A" end
+
+  if colorize == nil then colorize = true end
+
+  local minutesTotal = math.floor(seconds / 60)
+  local hoursTotal = math.floor(minutesTotal / 60)
+  local daysTotal = math.floor(hoursTotal / 24)
+
+  local years = math.floor(daysTotal / 365)
+  local daysAfterYears = daysTotal % 365
+  local months = math.floor(daysAfterYears / 30)
+  local days = daysAfterYears % 30
+  local hours = hoursTotal % 24
+  local minutes = minutesTotal % 60
+
+  local function unit(n, singular, plural)
+    local label = (n == 1) and singular or plural
+    local num = tostring(n)
+    if colorize then num = F.String.ToxiUI(num) end
+    return num .. " " .. label
+  end
+
+  if years > 0 then
+    if months > 0 then return unit(years, "Year", "Years") .. ", " .. unit(months, "Month", "Months") end
+    if days > 0 then return unit(years, "Year", "Years") .. ", " .. unit(days, "Day", "Days") end
+    if hours > 0 then return unit(years, "Year", "Years") .. ", " .. unit(hours, "Hour", "Hours") end
+    return unit(years, "Year", "Years") .. ", " .. unit(minutes, "Minute", "Minutes")
+  end
+
+  if months > 0 then
+    if days > 0 then return unit(months, "Month", "Months") .. ", " .. unit(days, "Day", "Days") end
+    if hours > 0 then return unit(months, "Month", "Months") .. ", " .. unit(hours, "Hour", "Hours") end
+    return unit(months, "Month", "Months") .. ", " .. unit(minutes, "Minute", "Minutes")
+  end
+
+  if days > 0 then
+    if hours > 0 then return unit(days, "Day", "Days") .. ", " .. unit(hours, "Hour", "Hours") end
+    return unit(days, "Day", "Days") .. ", " .. unit(minutes, "Minute", "Minutes")
+  end
+
+  if hours > 0 then return unit(hours, "Hour", "Hours") .. ", " .. unit(minutes, "Minute", "Minutes") end
+
+  if minutes > 0 then return unit(minutes, "Minute", "Minutes") end
+
+  return "Less than a minute"
+end
+
+-- Sum all stored played seconds across all characters/realms
+local function GetTotalPlayedAll()
+  local total = 0
+  local played = (E.global.TXUI and E.global.TXUI.playedSeconds) or {}
+  for _, realmMap in pairs(played) do
+    for _, seconds in pairs(realmMap) do
+      if seconds and seconds > 0 then total = total + seconds end
+    end
+  end
+  return total
+end
+
+function M:OnTimePlayed(_, totalTimePlayed, levelTimePlayed)
+  self.totalTimePlayed = totalTimePlayed
+  self.levelTimePlayed = levelTimePlayed
+  if self.played and self.played.total then
+    -- Update UI using sum across all characters
+    local sumAll = GetTotalPlayedAll() + (totalTimePlayed or 0)
+    self.played.total:SetText("Total: " .. FormatPlayed(sumAll))
+  end
+
+  -- Persist per-character seconds in ElvUI account-wide DB under TXUI
+  E.global.TXUI = E.global.TXUI or {}
+  E.global.TXUI.playedSeconds = E.global.TXUI.playedSeconds or {}
+  E.global.TXUI.playedSeconds[E.myrealm] = E.global.TXUI.playedSeconds[E.myrealm] or {}
+  E.global.TXUI.playedSeconds[E.myrealm][E.myname] = totalTimePlayed
+  -- Ensure class mapping exists for this character
+  E.global.TXUI.classMap = E.global.TXUI.classMap or {}
+  E.global.TXUI.classMap[E.myrealm] = E.global.TXUI.classMap[E.myrealm] or {}
+  E.global.TXUI.classMap[E.myrealm][E.myname] = E.myclass
+
+  -- Only handle once per login request
+  self:UnregisterEvent("TIME_PLAYED_MSG")
+end
+
+function M:OnPlayerEnteringWorld(_, isLogin, isReloadingUI)
+  -- Prepare persistent store for session start per character
+  E.global.TXUI = E.global.TXUI or {}
+  E.global.TXUI.sessionStartEpoch = E.global.TXUI.sessionStartEpoch or {}
+  E.global.TXUI.sessionStartEpoch[E.myrealm] = E.global.TXUI.sessionStartEpoch[E.myrealm] or {}
+
+  if isLogin then
+    -- Start a fresh session only on initial login
+    local now = time()
+    self.sessionStartEpoch = now
+    E.global.TXUI.sessionStartEpoch[E.myrealm][E.myname] = now
+
+    if not self._playedRequested then
+      self._playedRequested = true
+      self:RegisterEvent("TIME_PLAYED_MSG", "OnTimePlayed")
+      RequestTimePlayed()
+    end
+  elseif isReloadingUI then
+    -- On UI reload, restore the session start so the timer continues
+    local saved = E.global.TXUI.sessionStartEpoch[E.myrealm][E.myname]
+    if saved and saved > 0 then
+      self.sessionStartEpoch = saved
+    end
+    -- Do NOT request /played on reload; keep it to initial login only
+  else
+    -- Neither initial login nor reload (failsafe); try to restore if available
+    local saved = E.global.TXUI.sessionStartEpoch[E.myrealm][E.myname]
+    if saved and saved > 0 then self.sessionStartEpoch = saved end
+  end
+end
+
+local function AggregatePlayedByClass()
+  local totals = {}
+  local classes = (E.global.TXUI and E.global.TXUI.classMap) or {}
+  local played = (E.global.TXUI and E.global.TXUI.playedSeconds) or {}
+
+  for realm, classMap in pairs(classes) do
+    local playedRealm = played[realm]
+    if playedRealm then
+      for name, classToken in pairs(classMap) do
+        local seconds = playedRealm[name]
+        if seconds and seconds > 0 then
+          totals[classToken] = (totals[classToken] or 0) + seconds
+        end
+      end
+    end
+  end
+
+  local list = {}
+  for classToken, seconds in pairs(totals) do
+    table.insert(list, { class = classToken, seconds = seconds })
+  end
+  table.sort(list, function(a, b) return a.seconds > b.seconds end)
+  return list
+end
+
+
+function M:BuildPlayedGraph()
+  if not self.played or not self.backgroundFade then return end
+
+  -- Create container once
+  if not self.played.graph then
+    local graph = CreateFrame("Frame", nil, self.backgroundFade)
+    graph:SetPoint("TOPLEFT", (self.played.session or self.played.total), "BOTTOMLEFT", 0, m(-6))
+    graph:SetSize(700, 1) -- height will grow as bars are added
+    self.played.graph = graph
+    self.played.graph.bars = {}
+  end
+
+  local graph = self.played.graph
+  -- Clear previous bars
+  for _, bar in ipairs(graph.bars) do
+    bar:Hide()
+  end
+  wipe(graph.bars)
+
+  local aggregated = AggregatePlayedByClass()
+  if #aggregated == 0 then return end
+
+  local maxSeconds = aggregated[1].seconds
+  local maxWidth = 240
+  local barHeight = 16
+  local spacing = m(-2)
+
+  -- Color maps for class gradients
+  local fgMap = F.Color.GetMap("classColorMap")
+  local normalMap = fgMap and fgMap[I.Enum.GradientMode.Color.NORMAL]
+  local shiftMap = fgMap and fgMap[I.Enum.GradientMode.Color.SHIFT]
+
+  local yOffset = 0
+  for _, item in ipairs(aggregated) do
+    local barFrame = CreateFrame("Frame", nil, graph)
+    -- Increase left inset so the icon aligns better with other sections
+    barFrame:SetPoint("TOPLEFT", graph, "TOPLEFT", 24, yOffset)
+    barFrame:SetSize(maxWidth, barHeight)
+
+    -- Transparent black backdrop covering full bar width
+    local bg = barFrame:CreateTexture(nil, "BACKGROUND")
+    bg:SetPoint("LEFT", barFrame, "LEFT", 0, 0)
+    bg:SetSize(maxWidth, barHeight)
+    bg:SetColorTexture(0, 0, 0, 0.33)
+
+    -- ToxiUI class icon to the left (FontString with icon texture markup)
+    local iconFS = barFrame:CreateFontString(nil, "OVERLAY")
+    iconFS:SetPoint("RIGHT", barFrame, "LEFT", -4, 0)
+    -- Set a font before using texture markup to avoid FontString:SetText errors
+    iconFS:SetFont(F.GetFontPath(I.Fonts.Primary), F.FontSizeScaled(barHeight + 2), "")
+    -- Force ToxiUI class icon pack to ensure consistency
+    local iconTheme = "ToxiClasses"
+    local iconMarkup = string.format(M:GetClassIconPath(iconTheme), M.ClassIcons[item.class] or M.ClassIcons[E.myclass])
+    -- Downscale the icon from 32x32 to barHeight x barHeight for alignment
+    iconMarkup = iconMarkup:gsub("32:32", tostring(barHeight + 2) .. ":" .. tostring(barHeight + 2))
+    iconFS:SetText(iconMarkup)
+
+    -- Gradient bar texture sized by proportion
+    local width = math.max(2, math.floor((item.seconds / maxSeconds) * maxWidth))
+    local tex = barFrame:CreateTexture(nil, "ARTWORK")
+    tex:SetPoint("LEFT", barFrame, "LEFT", 0, 0)
+    tex:SetSize(width, barHeight)
+    tex:SetColorTexture(1, 1, 1, 1)
+
+    local start = shiftMap and shiftMap[item.class] or CreateColor(0.3, 0.3, 0.3, 1)
+    local finish = normalMap and normalMap[item.class] or CreateColor(0.6, 0.6, 0.6, 1)
+    F.Color.SetGradient(tex, "HORIZONTAL", start, finish)
+
+    -- No class name; layout is ICON | BAR | DURATION
+
+    -- Total time after the bar (outside, to the right)
+    local totalFS = barFrame:CreateFontString(nil, "OVERLAY")
+    totalFS:SetPoint("LEFT", barFrame, "RIGHT", 8, 0)
+    totalFS:SetJustifyH("LEFT")
+    totalFS:SetFont(F.GetFontPath(I.Fonts.Primary), F.FontSizeScaled(13), "OUTLINE")
+    totalFS:SetTextColor(1, 1, 1, 1)
+    totalFS:SetText(FormatPlayed(item.seconds, false))
+
+    table.insert(graph.bars, barFrame)
+    barFrame:Show()
+    yOffset = yOffset - (barHeight - spacing)
+  end
+
+  -- Resize container height to fit bars
+  graph:SetHeight((-yOffset) + barHeight)
+end
+
 function M:GameMenuButton()
   -- Don't init if its not a TXUI profile or requirements are not met
   if not TXUI:HasRequirements(I.Requirements.GameMenuButton) then return end
@@ -14,10 +246,6 @@ function M:GameMenuButton()
   -- Background Fade
   if E.db.TXUI.addons.gameMenuSkin.enabled then
     self.gamemenudb = E.db.TXUI.addons.gameMenuSkin
-    -- helper for margin value
-    local m = function(num)
-      return num * 4
-    end
 
     local outerSpacing = 100
 
@@ -34,6 +262,7 @@ function M:GameMenuButton()
     local backgroundFade = CreateFrame("Frame", nil, E.UIParent)
     local collections
     local mythic
+    local played
 
     backgroundFade:SetAllPoints(E.UIParent)
     backgroundFade:SetFrameStrata("HIGH")
@@ -59,7 +288,8 @@ function M:GameMenuButton()
       backgroundFade.bottomText:Point("BOTTOM", 0, outerSpacing)
       backgroundFade.bottomText:SetFont(primaryFont, F.FontSizeScaled(14), "OUTLINE")
       backgroundFade.bottomText:SetTextColor(1, 1, 1, 0.6)
-      backgroundFade.bottomText:SetText("You can find all the relevant " .. TXUI.Title .. " information at " .. I.Strings.Branding.Links.Website)
+      backgroundFade.bottomText:SetText("You can find all the relevant " ..
+        TXUI.Title .. " information at " .. I.Strings.Branding.Links.Website)
 
       -- Player Name
       backgroundFade.nameText = backgroundFade:CreateFontString(nil, "OVERLAY")
@@ -111,7 +341,7 @@ function M:GameMenuButton()
 
       -- Mounts
       collections.mount = backgroundFade:CreateFontString(nil, "OVERLAY")
-      collections.mount:SetPoint("TOPLEFT", collections, "BOTTOMLEFT", 0, m(-6))
+      collections.mount:SetPoint("TOPLEFT", collections, "BOTTOMLEFT", 0, m(-4))
       collections.mount:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
       collections.mount:SetTextColor(1, 1, 1, 1)
       collections.mount:SetText("Mounts: " .. F.String.ToxiUI(collectedMounts))
@@ -150,7 +380,7 @@ function M:GameMenuButton()
 
       -- Mythic+ keystone
       mythic.keystone = backgroundFade:CreateFontString(nil, "OVERLAY")
-      mythic.keystone:SetPoint("TOPLEFT", mythic, "BOTTOMLEFT", 0, m(-6))
+      mythic.keystone:SetPoint("TOPLEFT", mythic, "BOTTOMLEFT", 0, m(-4))
       mythic.keystone:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
       mythic.keystone:SetTextColor(1, 1, 1, 1)
 
@@ -164,7 +394,8 @@ function M:GameMenuButton()
 
       -- Mythic+ history
       mythic.latestRuns = backgroundFade:CreateFontString(nil, "OVERLAY")
-      mythic.latestRuns:SetPoint("TOPLEFT", self.gamemenudb.showMythicScore and mythic.score or mythic.keystone, "BOTTOMLEFT", 0, m(-4))
+      mythic.latestRuns:SetPoint("TOPLEFT", self.gamemenudb.showMythicScore and mythic.score or mythic.keystone,
+        "BOTTOMLEFT", 0, m(-4))
       mythic.latestRuns:SetFont(titleFont, F.FontSizeScaled(18), "OUTLINE")
 
       -- 10 = max history limit
@@ -181,6 +412,35 @@ function M:GameMenuButton()
       end
     end
 
+    -- Played section
+    if self.gamemenudb.showPlayed then
+      played = backgroundFade:CreateFontString(nil, "OVERLAY")
+      if mythic then
+        played:Point("TOPLEFT", mythic["history10"], "BOTTOMLEFT", 0, m(-12))
+      elseif self.gamemenudb.showCollections and collections and collections.achievs then
+        played:Point("TOPLEFT", collections.achievs, "BOTTOMLEFT", 0, m(-12))
+      else
+        played:Point("TOPLEFT", outerSpacing, -outerSpacing)
+      end
+      played:SetFont(titleFont, F.FontSizeScaled(24), "OUTLINE")
+      played:SetTextColor(1, 1, 1, 1)
+      played:SetText(F.String.GradientClass("Played"))
+
+      played.total = backgroundFade:CreateFontString(nil, "OVERLAY")
+      played.session = backgroundFade:CreateFontString(nil, "OVERLAY")
+
+      -- Session first (top), then Total under it
+      played.session:SetPoint("TOPLEFT", played, "BOTTOMLEFT", 0, m(-4))
+      played.session:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
+      played.session:SetTextColor(1, 1, 1, 1)
+      played.session:SetText("Session: " .. F.String.ToxiUI("Loading…"))
+
+      played.total:SetPoint("TOPLEFT", played.session, "BOTTOMLEFT", 0, m(-1))
+      played.total:SetFont(primaryFont, F.FontSizeScaled(16), "OUTLINE")
+      played.total:SetTextColor(1, 1, 1, 1)
+      played.total:SetText("Total: " .. F.String.ToxiUI("Loading…"))
+    end
+
     backgroundFade.Animation = TXUI:CreateAnimationGroup(backgroundFade):CreateAnimation("Fade")
     backgroundFade.Animation:SetEasing("out-quintic")
     backgroundFade.Animation:SetChange(1)
@@ -189,12 +449,14 @@ function M:GameMenuButton()
     self.backgroundFade = backgroundFade
     self.collections = collections
     self.mythic = mythic
+    self.played = played
     self.backgroundFade:Hide()
   end
 
   -- Hook show event cause blizzard resizes the menu
   self:SecureHookScript(GameMenuFrame, "OnShow", function()
     if self.backgroundFade and self.backgroundFade.Animation then
+      -- Build background and sections
       local bgColor
       local alpha = E.db.TXUI.addons.gameMenuSkin.bgColor.a
       if E.db.TXUI.addons.gameMenuSkin.classColor.enabled then
@@ -211,7 +473,8 @@ function M:GameMenuButton()
         self.backgroundFade.specIcon:SetFont(iconsFont, F.FontSizeScaled(E.db.TXUI.addons.gameMenuSkin.specIconSize), "")
         self.backgroundFade.specIcon:SetTextColor(1, 1, 1, 1)
 
-        self.backgroundFade.guildText:SetText(guildName and F.String.FastGradientHex("<" .. guildName .. ">", "06c910", "33ff3d") or "")
+        self.backgroundFade.guildText:SetText(guildName and
+          F.String.FastGradientHex("<" .. guildName .. ">", "06c910", "33ff3d") or "")
         self.backgroundFade.specIcon:SetText(specIcon)
         self.backgroundFade.levelText:SetText("Lv " .. E.mylevel)
         self.backgroundFade.classText:SetText(F.String.GradientClass(E.myLocalizedClass, nil, true))
@@ -220,7 +483,8 @@ function M:GameMenuButton()
       if self.collections then
         local _, petsOwned = C_PetJournal.GetNumPets()
         self.collections.pets:SetText("Pets: " .. F.String.ToxiUI(petsOwned))
-        self.collections.achievs:SetText("Achievement Points: " .. F.String.ToxiUI(E:FormatLargeNumber(GetTotalAchievementPoints(), ",")))
+        self.collections.achievs:SetText("Achievement Points: " ..
+          F.String.ToxiUI(E:FormatLargeNumber(GetTotalAchievementPoints(), ",")))
       end
 
       if self.mythic then
@@ -239,7 +503,10 @@ function M:GameMenuButton()
 
             -- Safely get hex color
             local levelColored = levelText
-            if colorObj and colorObj.GenerateHexColor then levelColored = F.String.Color(levelText, colorObj:GenerateHexColor()) end
+            if colorObj and colorObj.GenerateHexColor then
+              levelColored = F.String.Color(levelText,
+                colorObj:GenerateHexColor())
+            end
 
             text = keystoneTextPrefix .. F.String.ToxiUI(dungeonName .. " (" .. levelColored .. ")")
           else
@@ -281,7 +548,10 @@ function M:GameMenuButton()
                 local colorObj = C_ChallengeMode.GetKeystoneLevelRarityColor(historyRun.level)
                 local levelText = "+" .. historyRun.level
                 local levelColored = levelText
-                if colorObj and colorObj.GenerateHexColor then levelColored = F.String.Color(levelText, colorObj:GenerateHexColor()) end
+                if colorObj and colorObj.GenerateHexColor then
+                  levelColored = F.String.Color(levelText,
+                    colorObj:GenerateHexColor())
+                end
                 local output = ("%s (%s)"):format(historyDungeonName, levelColored)
                 historyFrame:SetText(historyRun.completed and F.String.Good(output) or F.String.Error(output))
               else
@@ -290,6 +560,42 @@ function M:GameMenuButton()
             end
           end
         end
+
+        -- Re-anchor Played section to the last visible history entry
+        if self.played then
+          local lastIndex = 0
+          for i = 1, 10 do
+            local f = self.mythic["history" .. i]
+            if f and f:GetText() and f:GetText() ~= "" then lastIndex = i end
+          end
+
+          local anchor = (lastIndex > 0) and self.mythic["history" .. lastIndex] or self.mythic.latestRuns
+          if anchor then
+            self.played:ClearAllPoints()
+            self.played:SetPoint("TOPLEFT", anchor, "BOTTOMLEFT", 0, m(-12))
+            if self.played.total and self.played.session then
+              -- Session at top, Total below
+              self.played.session:ClearAllPoints()
+              self.played.session:SetPoint("TOPLEFT", self.played, "BOTTOMLEFT", 0, m(-4))
+              self.played.total:ClearAllPoints()
+              self.played.total:SetPoint("TOPLEFT", self.played.session, "BOTTOMLEFT", 0, m(-1))
+            end
+          end
+        end
+      end
+
+      -- Update Played section from stored /played (requested at login)
+      if self.played then
+        local sumAll = GetTotalPlayedAll()
+        local text = (sumAll and sumAll > 0) and FormatPlayed(sumAll) or F.String.ToxiUI("Loading…")
+        self.played.total:SetText("Total: " .. text)
+        -- Update session based on elapsed since login
+        local sessionSec = (self.sessionStartEpoch and (time() - self.sessionStartEpoch)) or 0
+        if self.played.session then
+          local sessionText = (sessionSec > 0) and FormatPlayed(sessionSec, true) or F.String.ToxiUI("N/A")
+          self.played.session:SetText("Session: " .. sessionText)
+        end
+        self:BuildPlayedGraph()
       end
 
       if self.backgroundFade.tipText then
@@ -302,29 +608,32 @@ function M:GameMenuButton()
         local randomTip = randomTips[randomIndex]
 
         local monthDate = date("%m/%d") -- mm/dd eg 10/24 (oct 24)
-        local year = date("%Y") -- yyyy eg 2023
+        local year = date("%Y")         -- yyyy eg 2023
         local ToxiBirthday = monthDate == "01/06"
         local ToxiUiBirthday = monthDate == "10/18"
         local ToxiUiAge = year - 2020
         local holidays = { ["12/24"] = true, ["12/25"] = true, ["12/26"] = true }
-        local holidayString = holidays[monthDate] and "\n\nThe " .. TXUI.Title .. " team wishes you Happy Holidays!" or ""
+        local holidayString = holidays[monthDate] and "\n\nThe " .. TXUI.Title .. " team wishes you Happy Holidays!" or
+            ""
         -- let's call it an easter egg
         if ToxiBirthday then
           self.backgroundFade.tipText:SetText(
             "Did you know that today, January 6th, is "
-              .. F.String.ToxiUI("Toxi")
-              .. "'s birthday?\n"
-              .. F.String.ToxiUI("Fun fact:")
-              .. " First version of the "
-              .. TXUI.Title
-              .. " installer was released on this day back in 2021!"
+            .. F.String.ToxiUI("Toxi")
+            .. "'s birthday?\n"
+            .. F.String.ToxiUI("Fun fact:")
+            .. " First version of the "
+            .. TXUI.Title
+            .. " installer was released on this day back in 2021!"
           )
         elseif ToxiUiBirthday then
           self.backgroundFade.tipText:SetText(
-            "Did you know that today, October 18th, is " .. TXUI.Title .. "'s birthday? " .. TXUI.Title .. " is now " .. ToxiUiAge .. " years old!"
+            "Did you know that today, October 18th, is " ..
+            TXUI.Title .. "'s birthday? " .. TXUI.Title .. " is now " .. ToxiUiAge .. " years old!"
           )
         else
-          self.backgroundFade.tipText:SetText(F.String.ToxiUI("Random tip #" .. randomIndex .. ": ") .. randomTip .. holidayString)
+          self.backgroundFade.tipText:SetText(F.String.ToxiUI("Random tip #" .. randomIndex .. ": ") ..
+            randomTip .. holidayString)
         end
       end
 
@@ -338,6 +647,9 @@ function M:GameMenuButton()
   self:SecureHookScript(GameMenuFrame, "OnHide", function()
     if self.backgroundFade then self.backgroundFade:Hide() end
   end)
+
+  -- Request /played only on initial login
+  self:RegisterEvent("PLAYER_ENTERING_WORLD", "OnPlayerEnteringWorld")
 end
 
 M:AddCallback("GameMenuButton")

--- a/Modules/Options/Skins/GameMenuSkin.lua
+++ b/Modules/Options/Skins/GameMenuSkin.lua
@@ -18,7 +18,8 @@ function O:Skins_ElvUI()
     local mainGroup = self:AddInlineRequirementsDesc(options, {
       name = "Description",
     }, {
-      name = TXUI.Title .. " provides a skin for the Game Menu (ESC) that applies a background and additional information, all of which can be configured here.\n\n",
+      name = TXUI.Title ..
+      " provides a skin for the Game Menu (ESC) that applies a background and additional information, all of which can be configured here.\n\n",
     }, I.Requirements.GameMenuButton).args
 
     -- ToxiUI Game Menu Button Enable
@@ -46,7 +47,8 @@ function O:Skins_ElvUI()
     local backgroundGroup = self:AddInlineRequirementsDesc(options, {
       name = "Background",
     }, {
-      name = "Customize the color of the Game Menu Skin's background.\n\nThe " .. F.String.ToxiUI("Class Color") .. " option will override the " .. F.String.ToxiUI(
+      name = "Customize the color of the Game Menu Skin's background.\n\nThe " ..
+      F.String.ToxiUI("Class Color") .. " option will override the " .. F.String.ToxiUI(
         "Background Color"
       ) .. " option, but you can still use it to control the alpha of the background.\n\n",
     }, I.Requirements.GameMenuButton).args
@@ -140,6 +142,21 @@ function O:Skins_ElvUI()
       end,
       disabled = optionsDisabled,
       hidden = not TXUI.IsRetail,
+    }
+
+    infoGroup.showPlayed = {
+      order = self:GetOrder(),
+      type = "toggle",
+      name = "Show Played",
+      desc = "Toggling this on displays your total and session played time, plus per-class bars.",
+      get = function()
+        return E.db.TXUI.addons.gameMenuSkin.showPlayed
+      end,
+      set = function(_, value)
+        E.db.TXUI.addons.gameMenuSkin.showPlayed = value
+        E:StaticPopup_Show("CONFIG_RL")
+      end,
+      disabled = optionsDisabled,
     }
   end
 


### PR DESCRIPTION
Closes #
<img width="667" height="368" alt="image" src="https://github.com/user-attachments/assets/25aeb57c-51cc-489b-b98d-5ecf39e58ab1" />

# Summary of Changes
1. Adds a "Played" section to the GameMenu skin

# Description
This adds a new Played section to the GameMenu skin.

# To test
- [ ] Open the GameMenu skin

Sorry my formatter janked up the in-line comments, feel free to fix that. There is probably some optimizations or improvements but I wanted to get up a base PR.