### PR TITLE
📦 NEW: option to hide floating player frame on damage meter

### DIFF
--- a/Core/Profile.lua
+++ b/Core/Profile.lua
@@ -358,6 +358,7 @@ P.addons = {
     headerFade = true, -- Fade header on mouseover
     headerFadeMinAlpha = 0, -- Alpha when not hovering
     headerFadeMaxAlpha = 1, -- Alpha when hovering
+    hideLocalPlayerEntry = true, -- Enabled by default
   },
 }
 

--- a/Modules/Options/Skins/DamageMeter.lua
+++ b/Modules/Options/Skins/DamageMeter.lua
@@ -186,9 +186,9 @@ function O:Skins_DamageMeter()
   -- Hide Local Player Entry
   do
     local hideLocalPlayerGroup = self:AddInlineRequirementsDesc(options, {
-      name = "Hide Local Player Entry",
+      name = "Hide Floating Player Entry",
     }, {
-      name = "Hide your own character's entry from the Blizzard Damage Meter.\n\n",
+      name = "Hide your own character's entry from floating over the Blizzard Damage Meter.\n\n",
     }, I.Requirements.DamageMeter).args
 
     hideLocalPlayerGroup.hideLocalPlayerEntry = {
@@ -197,7 +197,7 @@ function O:Skins_DamageMeter()
       name = function()
         return self:GetEnableName(E.db.TXUI.addons.damageMeter.hideLocalPlayerEntry, hideLocalPlayerGroup)
       end,
-      desc = "Hide your own character's entry from the Blizzard Damage Meter.",
+      desc = "Hide your own character's entry from floating over the Blizzard Damage Meter.",
       disabled = function()
         return not TXUI:HasRequirements(I.Requirements.DamageMeter) or not E.db.TXUI.addons.damageMeter.enabled
       end,

--- a/Modules/Options/Skins/DamageMeter.lua
+++ b/Modules/Options/Skins/DamageMeter.lua
@@ -179,6 +179,37 @@ function O:Skins_DamageMeter()
       end,
     }
   end
+
+  -- Spacer
+  self:AddSpacer(options)
+
+  -- Hide Local Player Entry
+  do
+    local hideLocalPlayerGroup = self:AddInlineRequirementsDesc(options, {
+      name = "Hide Local Player Entry",
+    }, {
+      name = "Hide your own character's entry from the Blizzard Damage Meter.\n\n",
+    }, I.Requirements.DamageMeter).args
+
+    hideLocalPlayerGroup.hideLocalPlayerEntry = {
+      order = self:GetOrder(),
+      type = "toggle",
+      name = function()
+        return self:GetEnableName(E.db.TXUI.addons.damageMeter.hideLocalPlayerEntry, hideLocalPlayerGroup)
+      end,
+      desc = "Hide your own character's entry from the Blizzard Damage Meter.",
+      disabled = function()
+        return not TXUI:HasRequirements(I.Requirements.DamageMeter) or not E.db.TXUI.addons.damageMeter.enabled
+      end,
+      get = function(_)
+        return E.db.TXUI.addons.damageMeter.hideLocalPlayerEntry
+      end,
+      set = function(_, value)
+        E.db.TXUI.addons.damageMeter.hideLocalPlayerEntry = value
+        E:StaticPopup_Show("CONFIG_RL")
+      end,
+    }
+  end
 end
 
 if TXUI.IsRetail then O:AddCallback("Skins_DamageMeter") end

--- a/Modules/Skins/DamageMeter.lua
+++ b/Modules/Skins/DamageMeter.lua
@@ -220,8 +220,44 @@ local function HookScrollBox(scrollBox)
   if scrollBox.ForEachFrame then scrollBox:ForEachFrame(SkinMeter) end
 end
 
+-- Hide the "sticky self row" (LocalPlayerEntry) that floats while scrolling
+local function HideLocalPlayerEntry(window)
+  if not window or not window.LocalPlayerEntry then return end
+  if not E.db.TXUI.addons.damageMeter.hideLocalPlayerEntry then return end
+
+  local entry = window.LocalPlayerEntry
+  entry:Hide()
+  entry:SetAlpha(0)
+  entry:EnableMouse(false)
+end
+
+local function HookLocalPlayerEntry(window)
+  if not window or window.txuiLocalPlayerEntryHooked then return end
+  window.txuiLocalPlayerEntryHooked = true
+
+  -- Hide now
+  HideLocalPlayerEntry(window)
+
+  -- Prevent it from coming back on scroll/refresh
+  if window.ShowLocalPlayerEntry then hooksecurefunc(window, "ShowLocalPlayerEntry", function(self)
+    HideLocalPlayerEntry(self)
+  end) end
+
+  if window.EnsureLocalPlayerPresent then hooksecurefunc(window, "EnsureLocalPlayerPresent", function(self)
+    HideLocalPlayerEntry(self)
+  end) end
+
+  -- Safety: if the frame is shown for any reason, re-hide
+  window:HookScript("OnShow", function(self)
+    HideLocalPlayerEntry(self)
+  end)
+end
+
 local function HookSessionWindow(window)
   SkinHeader(window)
+
+  -- Hide sticky local player row
+  HookLocalPlayerEntry(window)
 
   local ScrollBox = window.GetScrollBox and window:GetScrollBox()
   if ScrollBox then HookScrollBox(ScrollBox) end


### PR DESCRIPTION
# Summary of Changes

1. Adds option to hide the floating player frame from the damage meter. This is unskinned from ElvUI currently. It can be skinned but has bugs so hiding it looks better.

# Description
<img width="1993" height="1645" alt="image" src="https://github.com/user-attachments/assets/4e9b570e-9d3e-4fb1-8c3e-9ce9b538e155" />

# To test

- [ ] Enabled by default, look at damage meter ;)
