### PR TITLE
feat(wb): Add AH/second mount middle-click option to Durability Submodule

### DIFF
--- a/Core/Profile.lua
+++ b/Core/Profile.lua
@@ -1203,6 +1203,7 @@ P.wunderbar = {
       iconColor = false,
       iconFontSize = 18,
 
+      auctionMount = 460,
       repairMount = 460,
 
       textColor = true,

--- a/Modules/Options/WunderBar/SubModules/Durability.lua
+++ b/Modules/Options/WunderBar/SubModules/Durability.lua
@@ -51,10 +51,21 @@ function O:WunderBar_SubModules_Durability()
   tab.generalGroup.args.showItemLevel = ACH:Toggle("Show Item Level", nil, 4)
   tab.generalGroup.args.itemLevelShort = ACH:Toggle("Short Item Level", nil, 5, nil, nil, nil, nil, nil, itemLevelDisabled)
 
+  -- Auction House Mount
+  tab.auctionGroup = ACH:Group("Auction House Mount", nil, 2)
+  tab.auctionGroup.inline = true
+  tab.auctionGroup.args.description = ACH:Description("Select which mount will be summoned when middle-clicking the module.\n\n", 1)
+  tab.auctionGroup.args.auctionMount = ACH:Select("Select Mount", nil, 2, getMounts)
+  tab.auctionGroup.args.auctionMount.width = 2
+  tab.auctionGroup.args.auctionMount.disabled = function()
+    return not (C_MountJournal and C_MountJournal.GetMountInfoByID) or F.Table.IsEmpty(getMounts())
+  end
+  tab.auctionGroup.args.auctionMount.sortByValue = true
+
   -- Repair Mount
-  tab.mountGroup = ACH:Group("Repair Mount", nil, 2)
+  tab.mountGroup = ACH:Group("Repair Mount", nil, 3)
   tab.mountGroup.inline = true
-  tab.mountGroup.args.description = ACH:Description("Select which repair mount will be summoned when right-clicking the module.\n\n", 1)
+  tab.mountGroup.args.description = ACH:Description("Select which mount will be summoned when right-clicking the module.\n\n", 1)
   tab.mountGroup.args.repairMount = ACH:Select("Select Mount", nil, 2, getMounts)
   tab.mountGroup.args.repairMount.width = 2
   tab.mountGroup.args.repairMount.disabled = function()
@@ -63,14 +74,14 @@ function O:WunderBar_SubModules_Durability()
   tab.mountGroup.args.repairMount.sortByValue = true
 
   -- Colors
-  tab.colorGroup = ACH:Group("Colors", nil, 3)
+  tab.colorGroup = ACH:Group("Colors", nil, 4)
   tab.colorGroup.inline = true
   tab.colorGroup.args.iconColor = ACH:Toggle("Color Icon", nil, 1, nil, nil, nil, nil, nil, iconDisabled)
   tab.colorGroup.args.textColor = ACH:Toggle("Color Text", nil, 2)
   tab.colorGroup.args.textColorFadeFromNormal = ACH:Toggle("Text Color as Base", nil, 3)
 
   -- Animations
-  tab.animateGroup = ACH:Group("Animations", nil, 4)
+  tab.animateGroup = ACH:Group("Animations", nil, 5)
   tab.animateGroup.inline = true
 
   tab.animateGroup.args.animateLow = ACH:Toggle("Animate Low", nil, 1)

--- a/Modules/WunderBar/SubModules/Durability.lua
+++ b/Modules/WunderBar/SubModules/Durability.lua
@@ -114,11 +114,19 @@ function DB:OnClick(...)
     if dtModule then dtModule.onClick(...) end
   end
 
+  if key == "MiddleButton" and (C_MountJournal and C_MountJournal.GetMountInfoByID) then
+    local auctionMountID = self.db.auctionMount
+    if auctionMountID then
+      local _, _, _, _, isUsable = C_MountJournal.GetMountInfoByID(auctionMountID)
+      if isUsable then C_MountJournal.SummonByID(auctionMountID) end
+    end
+  end
+
   if key == "RightButton" and (C_MountJournal and C_MountJournal.GetMountInfoByID) then
-    local mountID = self.db.repairMount
-    if mountID then
-      local _, _, _, _, isUsable = C_MountJournal.GetMountInfoByID(mountID)
-      if isUsable then C_MountJournal.SummonByID(mountID) end
+    local repairMountID = self.db.repairMount
+    if repairMountID then
+      local _, _, _, _, isUsable = C_MountJournal.GetMountInfoByID(repairMountID)
+      if isUsable then C_MountJournal.SummonByID(repairMountID) end
     end
   end
 end
@@ -162,9 +170,17 @@ function DB:OnEnter()
   DT.tooltip:AddLine(" ")
   DT.tooltip:AddLine("|cffFFFFFFLeft Click:|r Open Character Frame")
   if C_MountJournal and C_MountJournal.GetMountInfoByID then
-    local mountID = self.db.repairMount
-    if mountID then
-      local name, _, icon, _, isUsable = C_MountJournal.GetMountInfoByID(mountID)
+    local auctionMountID = self.db.auctionMount
+    local repairMountID = self.db.repairMount
+
+    if auctionMountID then
+      local name, _, icon, _, isUsable = C_MountJournal.GetMountInfoByID(auctionMountID)
+      local iconStr = icon and format("|T%s:16:16:0:0:50:50:4:46:4:46|t", icon) or ""
+      if name and isUsable then DT.tooltip:AddLine("|cffFFFFFFMiddle Click:|r Summon " .. iconStr .. name) end
+    end
+
+    if repairMountID then
+      local name, _, icon, _, isUsable = C_MountJournal.GetMountInfoByID(repairMountID)
       local iconStr = icon and format("|T%s:16:16:0:0:50:50:4:46:4:46|t", icon) or ""
       if name and isUsable then DT.tooltip:AddLine("|cffFFFFFFRight Click:|r Summon " .. iconStr .. name) end
     end


### PR DESCRIPTION
# Summary of Changes

1. Adds a middle-click second mount option onto the Wunderbar Durability submodule
2. Added/Reordered Durability submodule options as needed to place the middle click then right click mount options

# Description
I found myself wanting to be able to quick mount both AH or mog/repair mounts pretty often. Did an ugly copy paste of your existing repair mount and couldn't decide on a name for the options (auction house/repair vs mount1/2?).

# To test
Set two different mounts in the settings, middle click or right click the Durability module