### PR TITLE
fix: align Damage Meter skin with WindTools 4.21 session layout

### DIFF
--- a/Core/Changelog/7.5.5.lua
+++ b/Core/Changelog/7.5.5.lua
@@ -11,8 +11,14 @@ TXUI.Changelog["7.5.5"] = {
     "* Enhancements",
 
     "* Bug fixes",
+    F.String.Retail() .. "Damage Meter: Follow the new Blizzard session window layout" .. F.String.Sublist(
+      "Spell breakdown and floating player entry now use GetSourceWindow / GetLocalPlayerEntry"
+    ),
 
     "* Profile updates",
+    F.String.WindTools() .. ": Keep the Damage Meter header visible by default" .. F.String.Sublist(
+      "Header fade is handled by WindTools 4.21; mouseover is still available in WindTools settings"
+    ),
 
     "* Documentation",
 

--- a/Modules/Options/Skins/DamageMeter.lua
+++ b/Modules/Options/Skins/DamageMeter.lua
@@ -16,11 +16,38 @@ function O:Skins_DamageMeter()
   self:AddInlineDesc(options, {
     name = "Description",
   }, {
-    name = TXUI.Title .. " provides custom skinning for the " .. F.String.ToxiUI("Blizzard Damage Meter") .. " which can be configured here.\n\n",
+    name = TXUI.Title
+      .. " provides custom skinning for the "
+      .. F.String.ToxiUI("Blizzard Damage Meter")
+      .. " which can be configured here.\n\nHeader fade, window backdrop, and bar texture are configured in "
+      .. F.String.WindTools()
+      .. ".\n\n",
   })
 
   -- Spacer
   self:AddSpacer(options)
+
+  if F.IsAddOnEnabled("ElvUI_WindTools") then
+    local navGroup = self:AddInlineGroup(options, { name = "Related Settings" }).args
+
+    navGroup.navDesc = {
+      order = self:GetOrder(),
+      type = "description",
+      name = F.String.WindTools() .. " Skin - Header fade, window backdrop, scrollbar, and bar texture for the Blizzard Damage Meter.\n\n",
+    }
+
+    navGroup.windtoolsSkin = {
+      order = self:GetOrder(),
+      type = "execute",
+      name = F.String.WindTools() .. " Skin",
+      desc = "Open the " .. F.String.WindTools() .. " Skins > Damage Meter settings.",
+      func = function()
+        E:ToggleOptions("WindTools,skins,damageMeter")
+      end,
+    }
+
+    self:AddSpacer(options)
+  end
 
   -- General
   do

--- a/Modules/Profiles/ElvUI/Additional.lua
+++ b/Modules/Profiles/ElvUI/Additional.lua
@@ -300,7 +300,6 @@ function PF:BuildAdditionalPrivateProfile()
           covenantPreview = false,
           covenantRenown = false,
           covenantSanctum = false,
-          damageMeter = false,
           debugTools = false,
           delves = false,
           dressingRoom = false,
@@ -389,11 +388,12 @@ function PF:BuildAdditionalPrivateProfile()
         },
 
         damageMeter = {
+          enable = true,
           bar = {
             texture = I.Textures.Primary,
           },
           headerBackdrop = "hide",
-          headerPart = "mouseover",
+          headerPart = "always",
           scrollBar = "mouseover",
           windowBackdrop = "hide",
         },

--- a/Modules/Skins/DamageMeter.lua
+++ b/Modules/Skins/DamageMeter.lua
@@ -153,12 +153,27 @@ local function HookScrollBox(scrollBox)
 end
 
 -- Hide the "sticky self row" (LocalPlayerEntry) that floats while scrolling
+local function GetSessionLocalPlayerEntry(window)
+  if not window then return nil end
+  if window.GetLocalPlayerEntry then return window:GetLocalPlayerEntry() end
+
+  local container = window.MinimizeContainer or window
+  return container and container.LocalPlayerEntry
+end
+
+local function GetSessionSourceWindow(window)
+  if not window then return nil end
+  if window.GetSourceWindow then return window:GetSourceWindow() end
+
+  return window.SourceWindow
+end
+
 local function HideLocalPlayerEntry(window)
   if not E.db.TXUI.addons.damageMeter.hideLocalPlayerEntry then return end
-  local container = window.MinimizeContainer or window
-  if not container or not container.LocalPlayerEntry then return end
 
-  local entry = container.LocalPlayerEntry
+  local entry = GetSessionLocalPlayerEntry(window)
+  if not entry then return end
+
   entry:Hide()
   entry:SetAlpha(0)
   entry:EnableMouse(false)
@@ -187,15 +202,18 @@ local function HookLocalPlayerEntry(window)
 end
 
 local function HookSessionWindow(window)
+  if not window then return end
+
   -- Hide sticky local player row
   if E.db.TXUI.addons.damageMeter.hideLocalPlayerEntry then HookLocalPlayerEntry(window) end
 
-  local ScrollBox = window.GetScrollBox and window:GetScrollBox()
-  if ScrollBox then HookScrollBox(ScrollBox) end
+  local scrollBox = window.GetScrollBox and window:GetScrollBox()
+  if scrollBox then HookScrollBox(scrollBox) end
 
-  -- Source window (spell breakdown) has its own ScrollBox
-  if window.SourceWindow then
-    local sourceScrollBox = window.SourceWindow.GetScrollBox and window.SourceWindow:GetScrollBox()
+  -- Source window (spell breakdown) is under MinimizeContainer; use GetSourceWindow()
+  local sourceWindow = GetSessionSourceWindow(window)
+  if sourceWindow then
+    local sourceScrollBox = sourceWindow.GetScrollBox and sourceWindow:GetScrollBox()
     if sourceScrollBox then HookScrollBox(sourceScrollBox) end
   end
 end
@@ -222,8 +240,14 @@ function DM:Initialize()
         InvalidateGradientCache()
         F.Color.GenerateCache()
         _G.DamageMeter:ForEachSessionWindow(function(window)
-          local ScrollBox = window.GetScrollBox and window:GetScrollBox()
-          if ScrollBox and ScrollBox.ForEachFrame then ScrollBox:ForEachFrame(ApplyGradient) end
+          local scrollBox = window.GetScrollBox and window:GetScrollBox()
+          if scrollBox and scrollBox.ForEachFrame then scrollBox:ForEachFrame(ApplyGradient) end
+
+          local sourceWindow = GetSessionSourceWindow(window)
+          if sourceWindow then
+            local sourceScrollBox = sourceWindow.GetScrollBox and sourceWindow:GetScrollBox()
+            if sourceScrollBox and sourceScrollBox.ForEachFrame then sourceScrollBox:ForEachFrame(ApplyGradient) end
+          end
         end)
       end
 


### PR DESCRIPTION
Closes #

# Summary of Changes

1. Damage Meter skin uses the new Blizzard getters for the source window and floating player row.
2. WindTools profile: drop the old `skins.blizzard.damageMeter` toggle, show the header by default.
3. Added a button on the Damage Meter options to jump to the WindTools skin settings.

# Description

WindTools 4.21 changed how the Blizzard Damage Meter is laid out. The source window and floating player entry live under MinimizeContainer now, so `window.SourceWindow` is just nil and the breakdown never got skinned.

Header fade was removed in 7.4.0 in favor of WindTools. Two leftover issues:

- The installer still writes `skins.blizzard.damageMeter = false`, which WindTools doesn't have anymore. The real settings are under `skins.damageMeter`.
- The profile ships `headerPart = "mouseover"`. After 4.21 that fade is tied to the mixin's OnEnter / SetOnUpdateReason, so the header can just never show up.

Default is now always-visible. Mouseover is still there in WindTools if someone wants it. Existing characters need to hit Additional Private in the Profile Updater (or reinstall).

# To test

- [ ] WindTools on, apply Additional Private — header should be there without hovering
- [ ] Set WindTools header to Mouse Over and make sure fade still works
- [ ] Open a spell breakdown, icons/gradients should still apply
- [ ] Hide Floating Player Entry still hides the sticky self row
- [ ] WindTools Skin button opens WindTools > Skins > Damage Meter
- [ ] Without WindTools, the ToxiUI skin still works and that button is gone