### PR TITLE
Chore/shorten loadout names

### DIFF
--- a/Core/Changelog/7.5.5.lua
+++ b/Core/Changelog/7.5.5.lua
@@ -11,6 +11,7 @@ TXUI.Changelog["7.5.5"] = {
     "* Enhancements",
 
     "* Bug fixes",
+    F.String.Retail() .. "Fixed error on health bar backdrop/color updates due to secrets in Dark Mode",
 
     "* Profile updates",
 

--- a/Core/Changelog/7.5.5.lua
+++ b/Core/Changelog/7.5.5.lua
@@ -9,6 +9,7 @@ TXUI.Changelog["7.5.5"] = {
     "* New features",
 
     "* Enhancements",
+    F.String.Retail() .. "Added a max length setting to truncate long loadout names in " .. F.String.Menu.WunderBar(),
 
     "* Bug fixes",
     F.String.Retail() .. "Fixed error on health bar backdrop/color updates due to secrets in Dark Mode",
@@ -16,6 +17,7 @@ TXUI.Changelog["7.5.5"] = {
     "* Profile updates",
 
     "* Documentation",
+    F.String.MinElv("15.25"),
 
     "* Settings refactoring",
 

--- a/Core/Changelog/7.5.5.lua
+++ b/Core/Changelog/7.5.5.lua
@@ -21,7 +21,7 @@ TXUI.Changelog["7.5.5"] = {
     "* Profile updates",
 
     "* Documentation",
-    F.String.MinElv("15.25"),
+    F.String.MinElv("15.26"),
 
     "* Settings refactoring",
 

--- a/Core/Profile.lua
+++ b/Core/Profile.lua
@@ -1226,6 +1226,7 @@ P.wunderbar = {
         showSpec2 = false, -- loot spec
 
         showLoadout = true, -- Retail only, show current selected talent loadout
+        loadoutMaxLength = 20, -- Retail only, truncate the loadout name to this many characters
 
         iconFontSize = 18,
 

--- a/ElvUI_ToxiUI.toc
+++ b/ElvUI_ToxiUI.toc
@@ -11,7 +11,7 @@
 ## X-Flavor: Retail
 ## X-WoWI-ID: 25770
 ## X-Curse-Project-ID: 676447
-## X-ElvUIVersion: 15.25
+## X-ElvUIVersion: 15.26
 ## X-Wago-ID: XrNk5lKa
 ## X-GitHash: @project-version@
 ## AddonCompartmentFunc: ToxiUI_OnAddonCompartmentClick

--- a/ElvUI_ToxiUI_Mists.toc
+++ b/ElvUI_ToxiUI_Mists.toc
@@ -11,7 +11,7 @@
 ## X-Flavor: Classic
 ## X-WoWI-ID: 25770
 ## X-Curse-Project-ID: 676447
-## X-ElvUIVersion: 15.25
+## X-ElvUIVersion: 15.26
 ## X-Wago-ID: XrNk5lKa
 ## X-GitHash: @project-version@
 ## Group: ElvUI

--- a/ElvUI_ToxiUI_TBC.toc
+++ b/ElvUI_ToxiUI_TBC.toc
@@ -11,7 +11,7 @@
 ## X-Flavor: Anniversary
 ## X-WoWI-ID: 25770
 ## X-Curse-Project-ID: 676447
-## X-ElvUIVersion: 15.25
+## X-ElvUIVersion: 15.26
 ## X-Wago-ID: XrNk5lKa
 ## X-GitHash: @project-version@
 ## AddonCompartmentFunc: ToxiUI_OnAddonCompartmentClick

--- a/ElvUI_ToxiUI_Vanilla.toc
+++ b/ElvUI_ToxiUI_Vanilla.toc
@@ -11,7 +11,7 @@
 ## X-Flavor: ClassicEra
 ## X-WoWI-ID: 25770
 ## X-Curse-Project-ID: 676447
-## X-ElvUIVersion: 15.25
+## X-ElvUIVersion: 15.26
 ## X-Wago-ID: XrNk5lKa
 ## X-GitHash: @project-version@
 ## Group: ElvUI

--- a/Modules/Options/WunderBar/SubModules/SpecSwitch.lua
+++ b/Modules/Options/WunderBar/SubModules/SpecSwitch.lua
@@ -48,6 +48,16 @@ function O:WunderBar_SubModules_SpecSwitch()
   tab.generalGroup.args.showSpec2 = ACH:Toggle("Show " .. (TXUI.IsRetail and "Loot Spec" or "Secondary Spec"), nil, 7)
   tab.generalGroup.args.showLoadout = ACH:Toggle("Show Loadout Name", nil, 8, nil, nil, nil, nil, nil, not TXUI.IsRetail)
 
+  local loadoutDisabled = function()
+    return not TXUI.IsRetail or not E.db.TXUI.wunderbar.subModules[dbEntry].general.showLoadout
+  end
+
+  tab.generalGroup.args.loadoutMaxLength = ACH:Range("Loadout Name Max Length", nil, 9, {
+    min = 5,
+    max = 50,
+    step = 1,
+  }, nil, nil, nil, loadoutDisabled)
+
   -- Info Text
   tab.infoGroup = ACH:Group("Info Text Group", nil, 2)
   tab.infoGroup.inline = true

--- a/Modules/Themes/DarkTransparency.lua
+++ b/Modules/Themes/DarkTransparency.lua
@@ -24,14 +24,25 @@ function DT:PostUpdateColor(health, unit, r, g, b)
   local frame = health:GetParent()
   local elvUIColors = E.db.unitframe.colors
 
+  -- Apply same fix here that we did for the gradients.lua
+  if b ~= nil and (E:IsSecretValue(r) or E:IsSecretValue(g) or E:IsSecretValue(b)) then
+    r, g, b = nil, nil, nil
+  end
+
   -- fallback for bg if custom settings arent used
   if not b then
     r, g, b = elvUIColors.health.r, elvUIColors.health.g, elvUIColors.health.b
   end
 
   -- Charmed player should have hostile color
+  -- Some UnitIs* seem to be secret depending on context; guard every boolean
   if unit then
-    if (not UnitIsDeadOrGhost(unit)) and UnitIsConnected(unit) and UnitIsCharmed(unit) and UnitIsEnemy("player", unit) then
+    local isDeadOrGhost = UnitIsDeadOrGhost(unit)
+    local isConnected = UnitIsConnected(unit)
+    local isCharmed = UnitIsCharmed(unit)
+    local isEnemy = UnitIsEnemy("player", unit)
+
+    if E:NotSecretValue(isDeadOrGhost) and not isDeadOrGhost and E:NotSecretValue(isConnected) and isConnected and E:NotSecretValue(isCharmed) and isCharmed and E:NotSecretValue(isEnemy) and isEnemy then
       local color = frame.colors.reaction[HOSTILE_REACTION]
       if color then health:SetStatusBarColor(color[1], color[2], color[3]) end
     end
@@ -52,19 +63,21 @@ function DT:PostUpdateColor(health, unit, r, g, b)
     health.bg.multiplier = (elvUIColors.healthMultiplier > 0 and elvUIColors.healthMultiplier) or 0.35
 
     -- Custom Dead backdrop
-    if elvUIColors.useDeadBackdrop and (unit and UnitIsDeadOrGhost(unit)) then
+    local isDead = unit and UnitIsDeadOrGhost(unit)
+    if elvUIColors.useDeadBackdrop and E:NotSecretValue(isDead) and isDead then
       health.backdrop:SetBackdropColor(elvUIColors.health_backdrop_dead.r, elvUIColors.health_backdrop_dead.g, elvUIColors.health_backdrop_dead.b, self.transparencyAlpha)
     elseif elvUIColors.customhealthbackdrop then -- Custom Health Backdrop if not dead
       health.backdrop:SetBackdropColor(elvUIColors.health_backdrop.r, elvUIColors.health_backdrop.g, elvUIColors.health_backdrop.b, self.transparencyAlpha)
     elseif elvUIColors.classbackdrop and unit then
       local classColor
+      local isPlayerUnit = UnitIsPlayer(unit)
 
-      if UnitIsPlayer(unit) then
+      if E:NotSecretValue(isPlayerUnit) and isPlayerUnit then
         local unitClass = select(2, UnitClass(unit))
-        classColor = frame.colors.class[unitClass]
+        if E:NotSecretValue(unitClass) then classColor = frame.colors.class[unitClass] end
       else
         local reaction = UnitReaction(unit, "player")
-        if reaction then classColor = frame.colors.reaction[reaction] end
+        if E:NotSecretValue(reaction) and reaction then classColor = frame.colors.reaction[reaction] end
       end
 
       if classColor then

--- a/Modules/WunderBar/SubModules/SpecSwitch.lua
+++ b/Modules/WunderBar/SubModules/SpecSwitch.lua
@@ -392,6 +392,7 @@ function SS:UpdateElement(spec, frame, icon, text, isSecondary)
     end
 
     if loadoutName and not isSecondary and self.db.general.showLoadout then
+      loadoutName = E:ShortenString(loadoutName, self.db.general.loadoutMaxLength, true)
       text:SetText(self.db.general.useUppercase and F.String.Uppercase(loadoutName) or loadoutName)
     else
       text:SetText(self.db.general.useUppercase and F.String.Uppercase(info.name) or info.name)


### PR DESCRIPTION
<!--
Creating the PR.
- Fill the template, add/remove sections as needed.
-->

Closes #

<!-- If needed, link to design -->

# Summary of Changes

1. Added configurable slider to set truncation of loadout name in WunderBar
2. Guard secrets in Darkmode/transparency (secrets are a pain)

# Description

Was playing around with Talent loadout names, and found that with a long enough name, this would cause it to extend into modules to the left, which looked nicht gut. Added a configurable slider to change this, defaulted to 20.

Also guarded against some more boolean secrets from Blizz. Reproduction was to reload the game whilst on Dark mode/transparency, and all looks to be okay. Will continue to play with it to make sure.

# To test

- [ ] Add a loadout with long name, configure WunderBar to have module to left (I had exp/rep databar).
